### PR TITLE
separate names for cast_ray for discrete and continous worlds

### DIFF
--- a/src/RayCaster.jl
+++ b/src/RayCaster.jl
@@ -48,7 +48,7 @@ function cast_ray_continous_world(obstacle_tile_map::AbstractArray{Bool, 2}, x_s
     return i_stop, j_stop, hit_dimension, total_euclidean
 end
 
-function cast_ray(obstacle_tile_map::AbstractArray{Bool, 2}, i_start_world_units, j_start_world_units, delta_i_world_units, delta_j_world_units, world_units_per_tile_unit)
+function cast_ray_discrete_world(obstacle_tile_map::AbstractArray{Bool, 2}, i_start_world_units, j_start_world_units, delta_i_world_units, delta_j_world_units, world_units_per_tile_unit)
     I = typeof(i_start_world_units)
 
     i_start_tile_units = i_start_world_units ÷ world_units_per_tile_unit + one(I)

--- a/src/RayCaster.jl
+++ b/src/RayCaster.jl
@@ -1,6 +1,6 @@
 module RayCaster
 
-function cast_ray(obstacle_tile_map::AbstractArray{Bool, 2}, x_start::T1, y_start::T1, cos_theta::T2, sin_theta::T2) where {T1, T2}
+function cast_ray_continous_world(obstacle_tile_map::AbstractArray{Bool, 2}, x_start::T1, y_start::T1, cos_theta::T2, sin_theta::T2) where {T1, T2}
     i_start = floor(Int, x_start) + 1
     j_start = floor(Int, y_start) + 1
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,7 +24,7 @@ Test.@testset "RayCaster.jl" begin
             theta = convert(T2, 0)
             cos_theta = cos(theta)
             sin_theta = sin(theta)
-            i_stop, j_stop, hit_dimension, total_euclidean = RC.cast_ray(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
+            i_stop, j_stop, hit_dimension, total_euclidean = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
             Test.@test i_stop == 5
             Test.@test j_stop == 3
             Test.@test hit_dimension == 1
@@ -35,7 +35,7 @@ Test.@testset "RayCaster.jl" begin
             theta = convert(T2, atan(2 / 3))
             cos_theta = cos(theta)
             sin_theta = sin(theta)
-            i_stop, j_stop, hit_dimension, total_euclidean = RC.cast_ray(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
+            i_stop, j_stop, hit_dimension, total_euclidean = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
             Test.@test i_stop == 5
             Test.@test j_stop == 4
             Test.@test hit_dimension == 1
@@ -46,7 +46,7 @@ Test.@testset "RayCaster.jl" begin
             theta = convert(T2, (pi / 2) - atan(2 / 3))
             cos_theta = cos(theta)
             sin_theta = sin(theta)
-            i_stop, j_stop, hit_dimension, total_euclidean = RC.cast_ray(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
+            i_stop, j_stop, hit_dimension, total_euclidean = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
             Test.@test i_stop == 4
             Test.@test j_stop == 5
             Test.@test hit_dimension == 2
@@ -57,7 +57,7 @@ Test.@testset "RayCaster.jl" begin
             theta = convert(T2, pi / 2)
             cos_theta = cos(theta)
             sin_theta = sin(theta)
-            i_stop, j_stop, hit_dimension, total_euclidean = RC.cast_ray(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
+            i_stop, j_stop, hit_dimension, total_euclidean = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
             Test.@test i_stop == 3
             Test.@test j_stop == 5
             Test.@test hit_dimension == 2
@@ -68,7 +68,7 @@ Test.@testset "RayCaster.jl" begin
             theta = convert(T2, (pi / 2) + atan(2 / 3))
             cos_theta = cos(theta)
             sin_theta = sin(theta)
-            i_stop, j_stop, hit_dimension, total_euclidean = RC.cast_ray(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
+            i_stop, j_stop, hit_dimension, total_euclidean = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
             Test.@test i_stop == 2
             Test.@test j_stop == 5
             Test.@test hit_dimension == 2
@@ -79,7 +79,7 @@ Test.@testset "RayCaster.jl" begin
             theta = convert(T2, pi - atan(2 / 3))
             cos_theta = cos(theta)
             sin_theta = sin(theta)
-            i_stop, j_stop, hit_dimension, total_euclidean = RC.cast_ray(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
+            i_stop, j_stop, hit_dimension, total_euclidean = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
             Test.@test i_stop == 1
             Test.@test j_stop == 4
             Test.@test hit_dimension == 1
@@ -90,7 +90,7 @@ Test.@testset "RayCaster.jl" begin
             theta = convert(T2, pi)
             cos_theta = cos(theta)
             sin_theta = sin(theta)
-            i_stop, j_stop, hit_dimension, total_euclidean = RC.cast_ray(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
+            i_stop, j_stop, hit_dimension, total_euclidean = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
             Test.@test i_stop == 1
             Test.@test j_stop == 3
             Test.@test hit_dimension == 1
@@ -101,7 +101,7 @@ Test.@testset "RayCaster.jl" begin
             theta = convert(T2, pi + atan(2 / 3))
             cos_theta = cos(theta)
             sin_theta = sin(theta)
-            i_stop, j_stop, hit_dimension, total_euclidean = RC.cast_ray(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
+            i_stop, j_stop, hit_dimension, total_euclidean = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
             Test.@test i_stop == 1
             Test.@test j_stop == 2
             Test.@test hit_dimension == 1
@@ -112,7 +112,7 @@ Test.@testset "RayCaster.jl" begin
             theta = convert(T2, (3 * pi / 2) - atan(2 / 3))
             cos_theta = cos(theta)
             sin_theta = sin(theta)
-            i_stop, j_stop, hit_dimension, total_euclidean = RC.cast_ray(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
+            i_stop, j_stop, hit_dimension, total_euclidean = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
             Test.@test i_stop == 2
             Test.@test j_stop == 1
             Test.@test hit_dimension == 2
@@ -123,7 +123,7 @@ Test.@testset "RayCaster.jl" begin
             theta = convert(T2, 3 * pi / 2)
             cos_theta = cos(theta)
             sin_theta = sin(theta)
-            i_stop, j_stop, hit_dimension, total_euclidean = RC.cast_ray(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
+            i_stop, j_stop, hit_dimension, total_euclidean = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
             Test.@test i_stop == 3
             Test.@test j_stop == 1
             Test.@test hit_dimension == 2
@@ -134,7 +134,7 @@ Test.@testset "RayCaster.jl" begin
             theta = convert(T2, (3 * pi / 2) + atan(2 / 3))
             cos_theta = cos(theta)
             sin_theta = sin(theta)
-            i_stop, j_stop, hit_dimension, total_euclidean = RC.cast_ray(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
+            i_stop, j_stop, hit_dimension, total_euclidean = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
             Test.@test i_stop == 4
             Test.@test j_stop == 1
             Test.@test hit_dimension == 2
@@ -145,7 +145,7 @@ Test.@testset "RayCaster.jl" begin
             theta = convert(T2, 2 * pi - atan(2 / 3))
             cos_theta = cos(theta)
             sin_theta = sin(theta)
-            i_stop, j_stop, hit_dimension, total_euclidean = RC.cast_ray(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
+            i_stop, j_stop, hit_dimension, total_euclidean = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
             Test.@test i_stop == 5
             Test.@test j_stop == 2
             Test.@test hit_dimension == 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -163,7 +163,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = 0" begin
             delta_i_world_units = convert(I, 1)
             delta_j_world_units = convert(I, 0)
-            i_stop_tile_units, j_stop_tile_units, hit_dimension, delta_i_world_units_to_exit_start_tile, delta_j_world_units_to_exit_start_tile = RC.cast_ray(obstacle_tile_map, i_start_world_units, j_start_world_units, delta_i_world_units, delta_j_world_units, world_units_per_tile_unit)
+            i_stop_tile_units, j_stop_tile_units, hit_dimension, delta_i_world_units_to_exit_start_tile, delta_j_world_units_to_exit_start_tile = RC.cast_ray_discrete_world(obstacle_tile_map, i_start_world_units, j_start_world_units, delta_i_world_units, delta_j_world_units, world_units_per_tile_unit)
             Test.@test i_stop_tile_units == convert(I, 5)
             Test.@test j_stop_tile_units == convert(I, 3)
             Test.@test hit_dimension == 1
@@ -174,7 +174,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 2, delta_j = 1" begin
             delta_i_world_units = convert(I, 2)
             delta_j_world_units = convert(I, 1)
-            i_stop_tile_units, j_stop_tile_units, hit_dimension, delta_i_world_units_to_exit_start_tile, delta_j_world_units_to_exit_start_tile = RC.cast_ray(obstacle_tile_map, i_start_world_units, j_start_world_units, delta_i_world_units, delta_j_world_units, world_units_per_tile_unit)
+            i_stop_tile_units, j_stop_tile_units, hit_dimension, delta_i_world_units_to_exit_start_tile, delta_j_world_units_to_exit_start_tile = RC.cast_ray_discrete_world(obstacle_tile_map, i_start_world_units, j_start_world_units, delta_i_world_units, delta_j_world_units, world_units_per_tile_unit)
             Test.@test i_stop_tile_units == convert(I, 5)
             Test.@test j_stop_tile_units == convert(I, 4)
             Test.@test hit_dimension == 1
@@ -185,7 +185,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = 1" begin
             delta_i_world_units = convert(I, 1)
             delta_j_world_units = convert(I, 1)
-            i_stop_tile_units, j_stop_tile_units, hit_dimension, delta_i_world_units_to_exit_start_tile, delta_j_world_units_to_exit_start_tile = RC.cast_ray(obstacle_tile_map, i_start_world_units, j_start_world_units, delta_i_world_units, delta_j_world_units, world_units_per_tile_unit)
+            i_stop_tile_units, j_stop_tile_units, hit_dimension, delta_i_world_units_to_exit_start_tile, delta_j_world_units_to_exit_start_tile = RC.cast_ray_discrete_world(obstacle_tile_map, i_start_world_units, j_start_world_units, delta_i_world_units, delta_j_world_units, world_units_per_tile_unit)
             Test.@test i_stop_tile_units == convert(I, 5)
             Test.@test j_stop_tile_units == convert(I, 4)
             Test.@test hit_dimension == 1
@@ -196,7 +196,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = 2" begin
             delta_i_world_units = convert(I, 1)
             delta_j_world_units = convert(I, 2)
-            i_stop_tile_units, j_stop_tile_units, hit_dimension, delta_i_world_units_to_exit_start_tile, delta_j_world_units_to_exit_start_tile = RC.cast_ray(obstacle_tile_map, i_start_world_units, j_start_world_units, delta_i_world_units, delta_j_world_units, world_units_per_tile_unit)
+            i_stop_tile_units, j_stop_tile_units, hit_dimension, delta_i_world_units_to_exit_start_tile, delta_j_world_units_to_exit_start_tile = RC.cast_ray_discrete_world(obstacle_tile_map, i_start_world_units, j_start_world_units, delta_i_world_units, delta_j_world_units, world_units_per_tile_unit)
             Test.@test i_stop_tile_units == convert(I, 4)
             Test.@test j_stop_tile_units == convert(I, 5)
             Test.@test hit_dimension == 2
@@ -207,7 +207,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 0, delta_j = 1" begin
             delta_i_world_units = convert(I, 0)
             delta_j_world_units = convert(I, 1)
-            i_stop_tile_units, j_stop_tile_units, hit_dimension, delta_i_world_units_to_exit_start_tile, delta_j_world_units_to_exit_start_tile = RC.cast_ray(obstacle_tile_map, i_start_world_units, j_start_world_units, delta_i_world_units, delta_j_world_units, world_units_per_tile_unit)
+            i_stop_tile_units, j_stop_tile_units, hit_dimension, delta_i_world_units_to_exit_start_tile, delta_j_world_units_to_exit_start_tile = RC.cast_ray_discrete_world(obstacle_tile_map, i_start_world_units, j_start_world_units, delta_i_world_units, delta_j_world_units, world_units_per_tile_unit)
             Test.@test i_stop_tile_units == convert(I, 3)
             Test.@test j_stop_tile_units == convert(I, 5)
             Test.@test hit_dimension == 2
@@ -218,7 +218,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = 2" begin
             delta_i_world_units = convert(I, -1)
             delta_j_world_units = convert(I, 2)
-            i_stop_tile_units, j_stop_tile_units, hit_dimension, delta_i_world_units_to_exit_start_tile, delta_j_world_units_to_exit_start_tile = RC.cast_ray(obstacle_tile_map, i_start_world_units, j_start_world_units, delta_i_world_units, delta_j_world_units, world_units_per_tile_unit)
+            i_stop_tile_units, j_stop_tile_units, hit_dimension, delta_i_world_units_to_exit_start_tile, delta_j_world_units_to_exit_start_tile = RC.cast_ray_discrete_world(obstacle_tile_map, i_start_world_units, j_start_world_units, delta_i_world_units, delta_j_world_units, world_units_per_tile_unit)
             Test.@test i_stop_tile_units == convert(I, 2)
             Test.@test j_stop_tile_units == convert(I, 5)
             Test.@test hit_dimension == 2
@@ -229,7 +229,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = 1" begin
             delta_i_world_units = convert(I, -1)
             delta_j_world_units = convert(I, 1)
-            i_stop_tile_units, j_stop_tile_units, hit_dimension, delta_i_world_units_to_exit_start_tile, delta_j_world_units_to_exit_start_tile = RC.cast_ray(obstacle_tile_map, i_start_world_units, j_start_world_units, delta_i_world_units, delta_j_world_units, world_units_per_tile_unit)
+            i_stop_tile_units, j_stop_tile_units, hit_dimension, delta_i_world_units_to_exit_start_tile, delta_j_world_units_to_exit_start_tile = RC.cast_ray_discrete_world(obstacle_tile_map, i_start_world_units, j_start_world_units, delta_i_world_units, delta_j_world_units, world_units_per_tile_unit)
             Test.@test i_stop_tile_units == convert(I, 2)
             Test.@test j_stop_tile_units == convert(I, 5)
             Test.@test hit_dimension == 2
@@ -240,7 +240,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -2, delta_j = 1" begin
             delta_i_world_units = convert(I, -2)
             delta_j_world_units = convert(I, 1)
-            i_stop_tile_units, j_stop_tile_units, hit_dimension, delta_i_world_units_to_exit_start_tile, delta_j_world_units_to_exit_start_tile = RC.cast_ray(obstacle_tile_map, i_start_world_units, j_start_world_units, delta_i_world_units, delta_j_world_units, world_units_per_tile_unit)
+            i_stop_tile_units, j_stop_tile_units, hit_dimension, delta_i_world_units_to_exit_start_tile, delta_j_world_units_to_exit_start_tile = RC.cast_ray_discrete_world(obstacle_tile_map, i_start_world_units, j_start_world_units, delta_i_world_units, delta_j_world_units, world_units_per_tile_unit)
             Test.@test i_stop_tile_units == convert(I, 1)
             Test.@test j_stop_tile_units == convert(I, 4)
             Test.@test hit_dimension == 1
@@ -251,7 +251,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = 0" begin
             delta_i_world_units = convert(I, -1)
             delta_j_world_units = convert(I, 0)
-            i_stop_tile_units, j_stop_tile_units, hit_dimension, delta_i_world_units_to_exit_start_tile, delta_j_world_units_to_exit_start_tile = RC.cast_ray(obstacle_tile_map, i_start_world_units, j_start_world_units, delta_i_world_units, delta_j_world_units, world_units_per_tile_unit)
+            i_stop_tile_units, j_stop_tile_units, hit_dimension, delta_i_world_units_to_exit_start_tile, delta_j_world_units_to_exit_start_tile = RC.cast_ray_discrete_world(obstacle_tile_map, i_start_world_units, j_start_world_units, delta_i_world_units, delta_j_world_units, world_units_per_tile_unit)
             Test.@test i_stop_tile_units == convert(I, 1)
             Test.@test j_stop_tile_units == convert(I, 3)
             Test.@test hit_dimension == 1
@@ -262,7 +262,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -2, delta_j = -1" begin
             delta_i_world_units = convert(I, -2)
             delta_j_world_units = convert(I, -1)
-            i_stop_tile_units, j_stop_tile_units, hit_dimension, delta_i_world_units_to_exit_start_tile, delta_j_world_units_to_exit_start_tile = RC.cast_ray(obstacle_tile_map, i_start_world_units, j_start_world_units, delta_i_world_units, delta_j_world_units, world_units_per_tile_unit)
+            i_stop_tile_units, j_stop_tile_units, hit_dimension, delta_i_world_units_to_exit_start_tile, delta_j_world_units_to_exit_start_tile = RC.cast_ray_discrete_world(obstacle_tile_map, i_start_world_units, j_start_world_units, delta_i_world_units, delta_j_world_units, world_units_per_tile_unit)
             Test.@test i_stop_tile_units == convert(I, 1)
             Test.@test j_stop_tile_units == convert(I, 2)
             Test.@test hit_dimension == 1
@@ -273,7 +273,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = -1" begin
             delta_i_world_units = convert(I, -1)
             delta_j_world_units = convert(I, -1)
-            i_stop_tile_units, j_stop_tile_units, hit_dimension, delta_i_world_units_to_exit_start_tile, delta_j_world_units_to_exit_start_tile = RC.cast_ray(obstacle_tile_map, i_start_world_units, j_start_world_units, delta_i_world_units, delta_j_world_units, world_units_per_tile_unit)
+            i_stop_tile_units, j_stop_tile_units, hit_dimension, delta_i_world_units_to_exit_start_tile, delta_j_world_units_to_exit_start_tile = RC.cast_ray_discrete_world(obstacle_tile_map, i_start_world_units, j_start_world_units, delta_i_world_units, delta_j_world_units, world_units_per_tile_unit)
             Test.@test i_stop_tile_units == convert(I, 1)
             Test.@test j_stop_tile_units == convert(I, 2)
             Test.@test hit_dimension == 1
@@ -284,7 +284,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = -2" begin
             delta_i_world_units = convert(I, -1)
             delta_j_world_units = convert(I, -2)
-            i_stop_tile_units, j_stop_tile_units, hit_dimension, delta_i_world_units_to_exit_start_tile, delta_j_world_units_to_exit_start_tile = RC.cast_ray(obstacle_tile_map, i_start_world_units, j_start_world_units, delta_i_world_units, delta_j_world_units, world_units_per_tile_unit)
+            i_stop_tile_units, j_stop_tile_units, hit_dimension, delta_i_world_units_to_exit_start_tile, delta_j_world_units_to_exit_start_tile = RC.cast_ray_discrete_world(obstacle_tile_map, i_start_world_units, j_start_world_units, delta_i_world_units, delta_j_world_units, world_units_per_tile_unit)
             Test.@test i_stop_tile_units == convert(I, 2)
             Test.@test j_stop_tile_units == convert(I, 1)
             Test.@test hit_dimension == 2
@@ -295,7 +295,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 0, delta_j = -1" begin
             delta_i_world_units = convert(I, 0)
             delta_j_world_units = convert(I, -1)
-            i_stop_tile_units, j_stop_tile_units, hit_dimension, delta_i_world_units_to_exit_start_tile, delta_j_world_units_to_exit_start_tile = RC.cast_ray(obstacle_tile_map, i_start_world_units, j_start_world_units, delta_i_world_units, delta_j_world_units, world_units_per_tile_unit)
+            i_stop_tile_units, j_stop_tile_units, hit_dimension, delta_i_world_units_to_exit_start_tile, delta_j_world_units_to_exit_start_tile = RC.cast_ray_discrete_world(obstacle_tile_map, i_start_world_units, j_start_world_units, delta_i_world_units, delta_j_world_units, world_units_per_tile_unit)
             Test.@test i_stop_tile_units == convert(I, 3)
             Test.@test j_stop_tile_units == convert(I, 1)
             Test.@test hit_dimension == 2
@@ -306,7 +306,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = -2" begin
             delta_i_world_units = convert(I, 1)
             delta_j_world_units = convert(I, -2)
-            i_stop_tile_units, j_stop_tile_units, hit_dimension, delta_i_world_units_to_exit_start_tile, delta_j_world_units_to_exit_start_tile = RC.cast_ray(obstacle_tile_map, i_start_world_units, j_start_world_units, delta_i_world_units, delta_j_world_units, world_units_per_tile_unit)
+            i_stop_tile_units, j_stop_tile_units, hit_dimension, delta_i_world_units_to_exit_start_tile, delta_j_world_units_to_exit_start_tile = RC.cast_ray_discrete_world(obstacle_tile_map, i_start_world_units, j_start_world_units, delta_i_world_units, delta_j_world_units, world_units_per_tile_unit)
             Test.@test i_stop_tile_units == convert(I, 4)
             Test.@test j_stop_tile_units == convert(I, 1)
             Test.@test hit_dimension == 2
@@ -317,7 +317,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = -1" begin
             delta_i_world_units = convert(I, 1)
             delta_j_world_units = convert(I, -1)
-            i_stop_tile_units, j_stop_tile_units, hit_dimension, delta_i_world_units_to_exit_start_tile, delta_j_world_units_to_exit_start_tile = RC.cast_ray(obstacle_tile_map, i_start_world_units, j_start_world_units, delta_i_world_units, delta_j_world_units, world_units_per_tile_unit)
+            i_stop_tile_units, j_stop_tile_units, hit_dimension, delta_i_world_units_to_exit_start_tile, delta_j_world_units_to_exit_start_tile = RC.cast_ray_discrete_world(obstacle_tile_map, i_start_world_units, j_start_world_units, delta_i_world_units, delta_j_world_units, world_units_per_tile_unit)
             Test.@test i_stop_tile_units == convert(I, 5)
             Test.@test j_stop_tile_units == convert(I, 2)
             Test.@test hit_dimension == 1
@@ -328,7 +328,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 2, delta_j = -1" begin
             delta_i_world_units = convert(I, 2)
             delta_j_world_units = convert(I, -1)
-            i_stop_tile_units, j_stop_tile_units, hit_dimension, delta_i_world_units_to_exit_start_tile, delta_j_world_units_to_exit_start_tile = RC.cast_ray(obstacle_tile_map, i_start_world_units, j_start_world_units, delta_i_world_units, delta_j_world_units, world_units_per_tile_unit)
+            i_stop_tile_units, j_stop_tile_units, hit_dimension, delta_i_world_units_to_exit_start_tile, delta_j_world_units_to_exit_start_tile = RC.cast_ray_discrete_world(obstacle_tile_map, i_start_world_units, j_start_world_units, delta_i_world_units, delta_j_world_units, world_units_per_tile_unit)
             Test.@test i_stop_tile_units == convert(I, 5)
             Test.@test j_stop_tile_units == convert(I, 2)
             Test.@test hit_dimension == 1


### PR DESCRIPTION
1. Rename `cast_ray` method for continuous worlds as `cast_ray_continuous_world`.
2. Rename `cast_ray` method for discrete worlds as `cast_ray_discrete_world`.