### PR TITLE
make ray length info for continuous worlds consistent with discrete worlds

### DIFF
--- a/src/RayCaster.jl
+++ b/src/RayCaster.jl
@@ -4,7 +4,6 @@ function cast_ray_continous_world(obstacle_tile_map::AbstractArray{Bool, 2}, x_s
     i_start = floor(Int, x_start) + 1
     j_start = floor(Int, y_start) + 1
 
-    total_euclidean = zero(T1)
     delta_euclidean_per_unit_x = abs(1 / cos_theta)
     delta_euclidean_per_unit_y = abs(1 / sin_theta)
 
@@ -36,12 +35,10 @@ function cast_ray_continous_world(obstacle_tile_map::AbstractArray{Bool, 2}, x_s
     while !obstacle_tile_map[i_stop, j_stop]
 
         if (delta_euclidean_x <= delta_euclidean_y)
-            total_euclidean = delta_euclidean_x
             delta_euclidean_x += delta_euclidean_per_unit_x
             i_stop += delta_i
             hit_dimension = 1
         else
-            total_euclidean = delta_euclidean_y
             delta_euclidean_y += delta_euclidean_per_unit_y
             j_stop += delta_j
             hit_dimension = 2
@@ -49,7 +46,7 @@ function cast_ray_continous_world(obstacle_tile_map::AbstractArray{Bool, 2}, x_s
 
     end
 
-    return i_stop, j_stop, hit_dimension, total_euclidean, delta_x_world_units_to_exit_start_tile, delta_y_world_units_to_exit_start_tile
+    return i_stop, j_stop, hit_dimension, delta_x_world_units_to_exit_start_tile, delta_y_world_units_to_exit_start_tile
 end
 
 function cast_ray_discrete_world(obstacle_tile_map::AbstractArray{Bool, 2}, i_start_world_units, j_start_world_units, delta_i_world_units, delta_j_world_units, world_units_per_tile_unit)

--- a/src/RayCaster.jl
+++ b/src/RayCaster.jl
@@ -12,19 +12,23 @@ function cast_ray_continous_world(obstacle_tile_map::AbstractArray{Bool, 2}, x_s
 
     if cos_theta < zero(T2)
         delta_i = -1
-        delta_euclidean_x = (x_start - i_start + 1) * delta_euclidean_per_unit_x
+        delta_x_world_units_to_exit_start_tile = x_start - i_start + 1
     else
         delta_i = 1
-        delta_euclidean_x = (i_start - x_start) * delta_euclidean_per_unit_x
+        delta_x_world_units_to_exit_start_tile = i_start - x_start
     end
+
+    delta_euclidean_x = delta_x_world_units_to_exit_start_tile * delta_euclidean_per_unit_x
 
     if sin_theta < zero(T2)
         delta_j = -1
-        delta_euclidean_y = (y_start - j_start + 1) * delta_euclidean_per_unit_y
+        delta_y_world_units_to_exit_start_tile = y_start - j_start + 1
     else
         delta_j = 1
-        delta_euclidean_y = (j_start - y_start) * delta_euclidean_per_unit_y
+        delta_y_world_units_to_exit_start_tile = j_start - y_start
     end
+
+    delta_euclidean_y = delta_y_world_units_to_exit_start_tile * delta_euclidean_per_unit_y
 
     i_stop = i_start
     j_stop = j_start
@@ -45,7 +49,7 @@ function cast_ray_continous_world(obstacle_tile_map::AbstractArray{Bool, 2}, x_s
 
     end
 
-    return i_stop, j_stop, hit_dimension, total_euclidean
+    return i_stop, j_stop, hit_dimension, total_euclidean, delta_x_world_units_to_exit_start_tile, delta_y_world_units_to_exit_start_tile
 end
 
 function cast_ray_discrete_world(obstacle_tile_map::AbstractArray{Bool, 2}, i_start_world_units, j_start_world_units, delta_i_world_units, delta_j_world_units, world_units_per_tile_unit)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,132 +24,156 @@ Test.@testset "RayCaster.jl" begin
             theta = convert(T2, 0)
             cos_theta = cos(theta)
             sin_theta = sin(theta)
-            i_stop, j_stop, hit_dimension, total_euclidean = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
+            i_stop, j_stop, hit_dimension, total_euclidean, delta_x_world_units_to_exit_start_tile, delta_y_world_units_to_exit_start_tile = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
             Test.@test i_stop == 5
             Test.@test j_stop == 3
             Test.@test hit_dimension == 1
             Test.@test total_euclidean ≈ 1.5
+            Test.@test delta_x_world_units_to_exit_start_tile ≈ 0.5
+            Test.@test delta_y_world_units_to_exit_start_tile ≈ 0.5
         end
 
         Test.@testset "theta = atan(2 / 3)" begin
             theta = convert(T2, atan(2 / 3))
             cos_theta = cos(theta)
             sin_theta = sin(theta)
-            i_stop, j_stop, hit_dimension, total_euclidean = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
+            i_stop, j_stop, hit_dimension, total_euclidean, delta_x_world_units_to_exit_start_tile, delta_y_world_units_to_exit_start_tile = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
             Test.@test i_stop == 5
             Test.@test j_stop == 4
             Test.@test hit_dimension == 1
             Test.@test total_euclidean ≈ sqrt(1.5 ^ 2 + 1 ^ 2)
+            Test.@test delta_x_world_units_to_exit_start_tile ≈ 0.5
+            Test.@test delta_y_world_units_to_exit_start_tile ≈ 0.5
         end
 
         Test.@testset "theta = (pi / 2) - atan(2 / 3)" begin
             theta = convert(T2, (pi / 2) - atan(2 / 3))
             cos_theta = cos(theta)
             sin_theta = sin(theta)
-            i_stop, j_stop, hit_dimension, total_euclidean = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
+            i_stop, j_stop, hit_dimension, total_euclidean, delta_x_world_units_to_exit_start_tile, delta_y_world_units_to_exit_start_tile = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
             Test.@test i_stop == 4
             Test.@test j_stop == 5
             Test.@test hit_dimension == 2
             Test.@test total_euclidean ≈ sqrt(1.5 ^ 2 + 1 ^ 2)
+            Test.@test delta_x_world_units_to_exit_start_tile ≈ 0.5
+            Test.@test delta_y_world_units_to_exit_start_tile ≈ 0.5
         end
 
         Test.@testset "theta = pi / 2" begin
             theta = convert(T2, pi / 2)
             cos_theta = cos(theta)
             sin_theta = sin(theta)
-            i_stop, j_stop, hit_dimension, total_euclidean = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
+            i_stop, j_stop, hit_dimension, total_euclidean, delta_x_world_units_to_exit_start_tile, delta_y_world_units_to_exit_start_tile = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
             Test.@test i_stop == 3
             Test.@test j_stop == 5
             Test.@test hit_dimension == 2
             Test.@test total_euclidean ≈ 1.5
+            Test.@test delta_x_world_units_to_exit_start_tile ≈ 0.5
+            Test.@test delta_y_world_units_to_exit_start_tile ≈ 0.5
         end
 
         Test.@testset "theta = (pi / 2) + atan(2 / 3)" begin
             theta = convert(T2, (pi / 2) + atan(2 / 3))
             cos_theta = cos(theta)
             sin_theta = sin(theta)
-            i_stop, j_stop, hit_dimension, total_euclidean = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
+            i_stop, j_stop, hit_dimension, total_euclidean, delta_x_world_units_to_exit_start_tile, delta_y_world_units_to_exit_start_tile = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
             Test.@test i_stop == 2
             Test.@test j_stop == 5
             Test.@test hit_dimension == 2
             Test.@test total_euclidean ≈ sqrt(1.5 ^ 2 + 1 ^ 2)
+            Test.@test delta_x_world_units_to_exit_start_tile ≈ 0.5
+            Test.@test delta_y_world_units_to_exit_start_tile ≈ 0.5
         end
 
         Test.@testset "theta = pi - atan(2 / 3)" begin
             theta = convert(T2, pi - atan(2 / 3))
             cos_theta = cos(theta)
             sin_theta = sin(theta)
-            i_stop, j_stop, hit_dimension, total_euclidean = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
+            i_stop, j_stop, hit_dimension, total_euclidean, delta_x_world_units_to_exit_start_tile, delta_y_world_units_to_exit_start_tile = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
             Test.@test i_stop == 1
             Test.@test j_stop == 4
             Test.@test hit_dimension == 1
             Test.@test total_euclidean ≈ sqrt(1.5 ^ 2 + 1 ^ 2)
+            Test.@test delta_x_world_units_to_exit_start_tile ≈ 0.5
+            Test.@test delta_y_world_units_to_exit_start_tile ≈ 0.5
         end
 
         Test.@testset "theta = pi" begin
             theta = convert(T2, pi)
             cos_theta = cos(theta)
             sin_theta = sin(theta)
-            i_stop, j_stop, hit_dimension, total_euclidean = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
+            i_stop, j_stop, hit_dimension, total_euclidean, delta_x_world_units_to_exit_start_tile, delta_y_world_units_to_exit_start_tile = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
             Test.@test i_stop == 1
             Test.@test j_stop == 3
             Test.@test hit_dimension == 1
             Test.@test total_euclidean ≈ 1.5
+            Test.@test delta_x_world_units_to_exit_start_tile ≈ 0.5
+            Test.@test delta_y_world_units_to_exit_start_tile ≈ 0.5
         end
 
         Test.@testset "theta = pi + atan(2 / 3)" begin
             theta = convert(T2, pi + atan(2 / 3))
             cos_theta = cos(theta)
             sin_theta = sin(theta)
-            i_stop, j_stop, hit_dimension, total_euclidean = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
+            i_stop, j_stop, hit_dimension, total_euclidean, delta_x_world_units_to_exit_start_tile, delta_y_world_units_to_exit_start_tile = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
             Test.@test i_stop == 1
             Test.@test j_stop == 2
             Test.@test hit_dimension == 1
             Test.@test total_euclidean ≈ sqrt(1.5 ^ 2 + 1 ^ 2)
+            Test.@test delta_x_world_units_to_exit_start_tile ≈ 0.5
+            Test.@test delta_y_world_units_to_exit_start_tile ≈ 0.5
         end
 
         Test.@testset "theta = (3 * pi / 2) - atan(2 / 3)" begin
             theta = convert(T2, (3 * pi / 2) - atan(2 / 3))
             cos_theta = cos(theta)
             sin_theta = sin(theta)
-            i_stop, j_stop, hit_dimension, total_euclidean = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
+            i_stop, j_stop, hit_dimension, total_euclidean, delta_x_world_units_to_exit_start_tile, delta_y_world_units_to_exit_start_tile = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
             Test.@test i_stop == 2
             Test.@test j_stop == 1
             Test.@test hit_dimension == 2
             Test.@test total_euclidean ≈ sqrt(1.5 ^ 2 + 1 ^ 2)
+            Test.@test delta_x_world_units_to_exit_start_tile ≈ 0.5
+            Test.@test delta_y_world_units_to_exit_start_tile ≈ 0.5
         end
 
         Test.@testset "theta = 3 * pi / 2" begin
             theta = convert(T2, 3 * pi / 2)
             cos_theta = cos(theta)
             sin_theta = sin(theta)
-            i_stop, j_stop, hit_dimension, total_euclidean = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
+            i_stop, j_stop, hit_dimension, total_euclidean, delta_x_world_units_to_exit_start_tile, delta_y_world_units_to_exit_start_tile = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
             Test.@test i_stop == 3
             Test.@test j_stop == 1
             Test.@test hit_dimension == 2
             Test.@test total_euclidean ≈ 1.5
+            Test.@test delta_x_world_units_to_exit_start_tile ≈ 0.5
+            Test.@test delta_y_world_units_to_exit_start_tile ≈ 0.5
         end
 
         Test.@testset "theta = (3 * pi / 2) + atan(2 / 3)" begin
             theta = convert(T2, (3 * pi / 2) + atan(2 / 3))
             cos_theta = cos(theta)
             sin_theta = sin(theta)
-            i_stop, j_stop, hit_dimension, total_euclidean = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
+            i_stop, j_stop, hit_dimension, total_euclidean, delta_x_world_units_to_exit_start_tile, delta_y_world_units_to_exit_start_tile = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
             Test.@test i_stop == 4
             Test.@test j_stop == 1
             Test.@test hit_dimension == 2
             Test.@test total_euclidean ≈ sqrt(1.5 ^ 2 + 1 ^ 2)
+            Test.@test delta_x_world_units_to_exit_start_tile ≈ 0.5
+            Test.@test delta_y_world_units_to_exit_start_tile ≈ 0.5
         end
 
         Test.@testset "theta = 2 * pi - atan(2 / 3)" begin
             theta = convert(T2, 2 * pi - atan(2 / 3))
             cos_theta = cos(theta)
             sin_theta = sin(theta)
-            i_stop, j_stop, hit_dimension, total_euclidean = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
+            i_stop, j_stop, hit_dimension, total_euclidean, delta_x_world_units_to_exit_start_tile, delta_y_world_units_to_exit_start_tile = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
             Test.@test i_stop == 5
             Test.@test j_stop == 2
             Test.@test hit_dimension == 1
             Test.@test total_euclidean ≈ sqrt(1.5 ^ 2 + 1 ^ 2)
+            Test.@test delta_x_world_units_to_exit_start_tile ≈ 0.5
+            Test.@test delta_y_world_units_to_exit_start_tile ≈ 0.5
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,11 +24,11 @@ Test.@testset "RayCaster.jl" begin
             theta = convert(T2, 0)
             cos_theta = cos(theta)
             sin_theta = sin(theta)
-            i_stop, j_stop, hit_dimension, total_euclidean, delta_x_world_units_to_exit_start_tile, delta_y_world_units_to_exit_start_tile = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
+            i_stop, j_stop, hit_dimension, delta_x_world_units_to_exit_start_tile, delta_y_world_units_to_exit_start_tile = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
             Test.@test i_stop == 5
             Test.@test j_stop == 3
             Test.@test hit_dimension == 1
-            Test.@test total_euclidean ≈ 1.5
+            # Test.@test total_euclidean ≈ 1.5
             Test.@test delta_x_world_units_to_exit_start_tile ≈ 0.5
             Test.@test delta_y_world_units_to_exit_start_tile ≈ 0.5
         end
@@ -37,11 +37,11 @@ Test.@testset "RayCaster.jl" begin
             theta = convert(T2, atan(2 / 3))
             cos_theta = cos(theta)
             sin_theta = sin(theta)
-            i_stop, j_stop, hit_dimension, total_euclidean, delta_x_world_units_to_exit_start_tile, delta_y_world_units_to_exit_start_tile = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
+            i_stop, j_stop, hit_dimension, delta_x_world_units_to_exit_start_tile, delta_y_world_units_to_exit_start_tile = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
             Test.@test i_stop == 5
             Test.@test j_stop == 4
             Test.@test hit_dimension == 1
-            Test.@test total_euclidean ≈ sqrt(1.5 ^ 2 + 1 ^ 2)
+            # Test.@test total_euclidean ≈ sqrt(1.5 ^ 2 + 1 ^ 2)
             Test.@test delta_x_world_units_to_exit_start_tile ≈ 0.5
             Test.@test delta_y_world_units_to_exit_start_tile ≈ 0.5
         end
@@ -50,11 +50,11 @@ Test.@testset "RayCaster.jl" begin
             theta = convert(T2, (pi / 2) - atan(2 / 3))
             cos_theta = cos(theta)
             sin_theta = sin(theta)
-            i_stop, j_stop, hit_dimension, total_euclidean, delta_x_world_units_to_exit_start_tile, delta_y_world_units_to_exit_start_tile = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
+            i_stop, j_stop, hit_dimension, delta_x_world_units_to_exit_start_tile, delta_y_world_units_to_exit_start_tile = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
             Test.@test i_stop == 4
             Test.@test j_stop == 5
             Test.@test hit_dimension == 2
-            Test.@test total_euclidean ≈ sqrt(1.5 ^ 2 + 1 ^ 2)
+            # Test.@test total_euclidean ≈ sqrt(1.5 ^ 2 + 1 ^ 2)
             Test.@test delta_x_world_units_to_exit_start_tile ≈ 0.5
             Test.@test delta_y_world_units_to_exit_start_tile ≈ 0.5
         end
@@ -63,11 +63,11 @@ Test.@testset "RayCaster.jl" begin
             theta = convert(T2, pi / 2)
             cos_theta = cos(theta)
             sin_theta = sin(theta)
-            i_stop, j_stop, hit_dimension, total_euclidean, delta_x_world_units_to_exit_start_tile, delta_y_world_units_to_exit_start_tile = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
+            i_stop, j_stop, hit_dimension, delta_x_world_units_to_exit_start_tile, delta_y_world_units_to_exit_start_tile = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
             Test.@test i_stop == 3
             Test.@test j_stop == 5
             Test.@test hit_dimension == 2
-            Test.@test total_euclidean ≈ 1.5
+            # Test.@test total_euclidean ≈ 1.5
             Test.@test delta_x_world_units_to_exit_start_tile ≈ 0.5
             Test.@test delta_y_world_units_to_exit_start_tile ≈ 0.5
         end
@@ -76,11 +76,11 @@ Test.@testset "RayCaster.jl" begin
             theta = convert(T2, (pi / 2) + atan(2 / 3))
             cos_theta = cos(theta)
             sin_theta = sin(theta)
-            i_stop, j_stop, hit_dimension, total_euclidean, delta_x_world_units_to_exit_start_tile, delta_y_world_units_to_exit_start_tile = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
+            i_stop, j_stop, hit_dimension, delta_x_world_units_to_exit_start_tile, delta_y_world_units_to_exit_start_tile = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
             Test.@test i_stop == 2
             Test.@test j_stop == 5
             Test.@test hit_dimension == 2
-            Test.@test total_euclidean ≈ sqrt(1.5 ^ 2 + 1 ^ 2)
+            # Test.@test total_euclidean ≈ sqrt(1.5 ^ 2 + 1 ^ 2)
             Test.@test delta_x_world_units_to_exit_start_tile ≈ 0.5
             Test.@test delta_y_world_units_to_exit_start_tile ≈ 0.5
         end
@@ -89,11 +89,11 @@ Test.@testset "RayCaster.jl" begin
             theta = convert(T2, pi - atan(2 / 3))
             cos_theta = cos(theta)
             sin_theta = sin(theta)
-            i_stop, j_stop, hit_dimension, total_euclidean, delta_x_world_units_to_exit_start_tile, delta_y_world_units_to_exit_start_tile = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
+            i_stop, j_stop, hit_dimension, delta_x_world_units_to_exit_start_tile, delta_y_world_units_to_exit_start_tile = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
             Test.@test i_stop == 1
             Test.@test j_stop == 4
             Test.@test hit_dimension == 1
-            Test.@test total_euclidean ≈ sqrt(1.5 ^ 2 + 1 ^ 2)
+            # Test.@test total_euclidean ≈ sqrt(1.5 ^ 2 + 1 ^ 2)
             Test.@test delta_x_world_units_to_exit_start_tile ≈ 0.5
             Test.@test delta_y_world_units_to_exit_start_tile ≈ 0.5
         end
@@ -102,11 +102,11 @@ Test.@testset "RayCaster.jl" begin
             theta = convert(T2, pi)
             cos_theta = cos(theta)
             sin_theta = sin(theta)
-            i_stop, j_stop, hit_dimension, total_euclidean, delta_x_world_units_to_exit_start_tile, delta_y_world_units_to_exit_start_tile = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
+            i_stop, j_stop, hit_dimension, delta_x_world_units_to_exit_start_tile, delta_y_world_units_to_exit_start_tile = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
             Test.@test i_stop == 1
             Test.@test j_stop == 3
             Test.@test hit_dimension == 1
-            Test.@test total_euclidean ≈ 1.5
+            # Test.@test total_euclidean ≈ 1.5
             Test.@test delta_x_world_units_to_exit_start_tile ≈ 0.5
             Test.@test delta_y_world_units_to_exit_start_tile ≈ 0.5
         end
@@ -115,11 +115,11 @@ Test.@testset "RayCaster.jl" begin
             theta = convert(T2, pi + atan(2 / 3))
             cos_theta = cos(theta)
             sin_theta = sin(theta)
-            i_stop, j_stop, hit_dimension, total_euclidean, delta_x_world_units_to_exit_start_tile, delta_y_world_units_to_exit_start_tile = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
+            i_stop, j_stop, hit_dimension, delta_x_world_units_to_exit_start_tile, delta_y_world_units_to_exit_start_tile = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
             Test.@test i_stop == 1
             Test.@test j_stop == 2
             Test.@test hit_dimension == 1
-            Test.@test total_euclidean ≈ sqrt(1.5 ^ 2 + 1 ^ 2)
+            # Test.@test total_euclidean ≈ sqrt(1.5 ^ 2 + 1 ^ 2)
             Test.@test delta_x_world_units_to_exit_start_tile ≈ 0.5
             Test.@test delta_y_world_units_to_exit_start_tile ≈ 0.5
         end
@@ -128,11 +128,11 @@ Test.@testset "RayCaster.jl" begin
             theta = convert(T2, (3 * pi / 2) - atan(2 / 3))
             cos_theta = cos(theta)
             sin_theta = sin(theta)
-            i_stop, j_stop, hit_dimension, total_euclidean, delta_x_world_units_to_exit_start_tile, delta_y_world_units_to_exit_start_tile = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
+            i_stop, j_stop, hit_dimension, delta_x_world_units_to_exit_start_tile, delta_y_world_units_to_exit_start_tile = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
             Test.@test i_stop == 2
             Test.@test j_stop == 1
             Test.@test hit_dimension == 2
-            Test.@test total_euclidean ≈ sqrt(1.5 ^ 2 + 1 ^ 2)
+            # Test.@test total_euclidean ≈ sqrt(1.5 ^ 2 + 1 ^ 2)
             Test.@test delta_x_world_units_to_exit_start_tile ≈ 0.5
             Test.@test delta_y_world_units_to_exit_start_tile ≈ 0.5
         end
@@ -141,11 +141,11 @@ Test.@testset "RayCaster.jl" begin
             theta = convert(T2, 3 * pi / 2)
             cos_theta = cos(theta)
             sin_theta = sin(theta)
-            i_stop, j_stop, hit_dimension, total_euclidean, delta_x_world_units_to_exit_start_tile, delta_y_world_units_to_exit_start_tile = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
+            i_stop, j_stop, hit_dimension, delta_x_world_units_to_exit_start_tile, delta_y_world_units_to_exit_start_tile = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
             Test.@test i_stop == 3
             Test.@test j_stop == 1
             Test.@test hit_dimension == 2
-            Test.@test total_euclidean ≈ 1.5
+            # Test.@test total_euclidean ≈ 1.5
             Test.@test delta_x_world_units_to_exit_start_tile ≈ 0.5
             Test.@test delta_y_world_units_to_exit_start_tile ≈ 0.5
         end
@@ -154,11 +154,11 @@ Test.@testset "RayCaster.jl" begin
             theta = convert(T2, (3 * pi / 2) + atan(2 / 3))
             cos_theta = cos(theta)
             sin_theta = sin(theta)
-            i_stop, j_stop, hit_dimension, total_euclidean, delta_x_world_units_to_exit_start_tile, delta_y_world_units_to_exit_start_tile = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
+            i_stop, j_stop, hit_dimension, delta_x_world_units_to_exit_start_tile, delta_y_world_units_to_exit_start_tile = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
             Test.@test i_stop == 4
             Test.@test j_stop == 1
             Test.@test hit_dimension == 2
-            Test.@test total_euclidean ≈ sqrt(1.5 ^ 2 + 1 ^ 2)
+            # Test.@test total_euclidean ≈ sqrt(1.5 ^ 2 + 1 ^ 2)
             Test.@test delta_x_world_units_to_exit_start_tile ≈ 0.5
             Test.@test delta_y_world_units_to_exit_start_tile ≈ 0.5
         end
@@ -167,11 +167,11 @@ Test.@testset "RayCaster.jl" begin
             theta = convert(T2, 2 * pi - atan(2 / 3))
             cos_theta = cos(theta)
             sin_theta = sin(theta)
-            i_stop, j_stop, hit_dimension, total_euclidean, delta_x_world_units_to_exit_start_tile, delta_y_world_units_to_exit_start_tile = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
+            i_stop, j_stop, hit_dimension, delta_x_world_units_to_exit_start_tile, delta_y_world_units_to_exit_start_tile = RC.cast_ray_continous_world(obstacle_tile_map, x_start, y_start, cos_theta, sin_theta)
             Test.@test i_stop == 5
             Test.@test j_stop == 2
             Test.@test hit_dimension == 1
-            Test.@test total_euclidean ≈ sqrt(1.5 ^ 2 + 1 ^ 2)
+            # Test.@test total_euclidean ≈ sqrt(1.5 ^ 2 + 1 ^ 2)
             Test.@test delta_x_world_units_to_exit_start_tile ≈ 0.5
             Test.@test delta_y_world_units_to_exit_start_tile ≈ 0.5
         end


### PR DESCRIPTION
Remove ray length given by `total_euclidean` from `cast_ray_continuous_worlds` and instead add `delta_x_world_units_to_exit_start_tile` and `delta_y_world_units_to_exit_start_tile`.