### PR TITLE
add ray stop coordinates

### DIFF
--- a/src/RayCaster.jl
+++ b/src/RayCaster.jl
@@ -1,57 +1,57 @@
 module RayCaster
 
-function cast_ray(obstacle_tile_map::AbstractArray{Bool, 2}, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+function cast_ray(obstacle_tile_map::AbstractArray{Bool, 2}, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
     @assert !(iszero(i_ray_direction) && iszero(j_ray_direction))
 
-    i_ray_start_tile = fld1(i_ray_start, height_tile)
-    j_ray_start_tile = fld1(j_ray_start, height_tile)
+    i_ray_start_tile = fld1(i_ray_start, tile_length)
+    j_ray_start_tile = fld1(j_ray_start, tile_length)
 
-    return cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_start_tile, j_ray_start_tile, i_ray_direction, j_ray_direction, max_steps)
+    return cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_start_tile, j_ray_start_tile, i_ray_direction, j_ray_direction, max_steps)
 end
 
-function cast_ray(obstacle_tile_map::AbstractArray{Bool, 2}, height_tile, i_ray_start, j_ray_start, i_ray_start_tile, j_ray_start_tile, i_ray_direction, j_ray_direction, max_steps)
+function cast_ray(obstacle_tile_map::AbstractArray{Bool, 2}, tile_length, i_ray_start, j_ray_start, i_ray_start_tile, j_ray_start_tile, i_ray_direction, j_ray_direction, max_steps)
     @assert !(iszero(i_ray_direction) && iszero(j_ray_direction))
 
     I = typeof(i_ray_start)
 
     if i_ray_direction < zero(I)
         i_tile_step_size = -one(I)
-        cells_travelled_along_i_axis_to_exit_ray_start_tile = (i_ray_start - (i_ray_start_tile - one(I)) * height_tile - one(I))
+        cells_travelled_along_i_axis_to_exit_ray_start_tile = (i_ray_start - (i_ray_start_tile - one(I)) * tile_length - one(I))
         sign_i_ray_direction = -one(I)
         abs_i_ray_direction = -i_ray_direction
     elseif i_ray_direction > zero(I)
         i_tile_step_size = one(I)
-        cells_travelled_along_i_axis_to_exit_ray_start_tile = (i_ray_start_tile * height_tile + one(I)- i_ray_start)
+        cells_travelled_along_i_axis_to_exit_ray_start_tile = (i_ray_start_tile * tile_length + one(I)- i_ray_start)
         sign_i_ray_direction = one(I)
         abs_i_ray_direction = i_ray_direction
     else
         i_tile_step_size = zero(I)
-        cells_travelled_along_i_axis_to_exit_ray_start_tile = (i_ray_start_tile * height_tile + one(I) - i_ray_start)
+        cells_travelled_along_i_axis_to_exit_ray_start_tile = (i_ray_start_tile * tile_length + one(I) - i_ray_start)
         sign_i_ray_direction = i_ray_direction
         abs_i_ray_direction = i_ray_direction
     end
 
     if j_ray_direction < zero(I)
         j_tile_step_size = -one(I)
-        cells_travelled_along_j_axis_to_exit_ray_start_tile = (j_ray_start - (j_ray_start_tile - one(I)) * height_tile - one(I))
+        cells_travelled_along_j_axis_to_exit_ray_start_tile = (j_ray_start - (j_ray_start_tile - one(I)) * tile_length - one(I))
         sign_j_ray_direction = -one(I)
         abs_j_ray_direction = -j_ray_direction
     elseif j_ray_direction > zero(I)
         j_tile_step_size = one(I)
-        cells_travelled_along_j_axis_to_exit_ray_start_tile = (j_ray_start_tile * height_tile + one(I)- j_ray_start)
+        cells_travelled_along_j_axis_to_exit_ray_start_tile = (j_ray_start_tile * tile_length + one(I)- j_ray_start)
         sign_j_ray_direction = one(I)
         abs_j_ray_direction = j_ray_direction
     else
         j_tile_step_size = zero(I)
-        cells_travelled_along_j_axis_to_exit_ray_start_tile = (j_ray_start_tile * height_tile + one(I)- j_ray_start)
+        cells_travelled_along_j_axis_to_exit_ray_start_tile = (j_ray_start_tile * tile_length + one(I)- j_ray_start)
         sign_j_ray_direction = j_ray_direction
         abs_j_ray_direction = j_ray_direction
     end
 
     height_ray_direction_triangle = abs_i_ray_direction + one(I)
     width_ray_direction_triangle = abs_j_ray_direction + one(I)
-    scaled_increase_in_ray_length_per_tile_travelled_along_i_axis = height_tile * abs_j_ray_direction
-    scaled_increase_in_ray_length_per_tile_travelled_along_j_axis = height_tile * abs_i_ray_direction
+    scaled_increase_in_ray_length_per_tile_travelled_along_i_axis = tile_length * abs_j_ray_direction
+    scaled_increase_in_ray_length_per_tile_travelled_along_j_axis = tile_length * abs_i_ray_direction
 
     scaled_ray_length_when_traveling_along_i_axis = cells_travelled_along_i_axis_to_exit_ray_start_tile * abs_j_ray_direction
     scaled_ray_length_when_traveling_along_j_axis = cells_travelled_along_j_axis_to_exit_ray_start_tile * abs_i_ray_direction
@@ -77,20 +77,20 @@ function cast_ray(obstacle_tile_map::AbstractArray{Bool, 2}, height_tile, i_ray_
     end
 
     if hit_dimension == 1
-        height_ray_triangle = cells_travelled_along_i_axis_to_exit_ray_start_tile + (i_steps_taken - one(I)) * height_tile
+        height_ray_triangle = cells_travelled_along_i_axis_to_exit_ray_start_tile + (i_steps_taken - one(I)) * tile_length
         width_ray_triangle = (height_ray_triangle * abs_j_ray_direction) // abs_i_ray_direction
         rounded_width_ray_triangle = round(I, width_ray_triangle, RoundDown)
         i_ray_stop = i_ray_start + sign_i_ray_direction * height_ray_triangle
-        j_ray_stop_high = j_ray_hit_tile * height_tile
-        j_ray_stop_low = j_ray_stop_high - height_tile + one(I)
+        j_ray_stop_high = j_ray_hit_tile * tile_length
+        j_ray_stop_low = j_ray_stop_high - tile_length + one(I)
         j_ray_stop = clamp(j_ray_start + sign_j_ray_direction * rounded_width_ray_triangle, j_ray_stop_low, j_ray_stop_high)
     elseif hit_dimension == 2
-        width_ray_triangle = cells_travelled_along_j_axis_to_exit_ray_start_tile + (j_steps_taken - one(I)) * height_tile
+        width_ray_triangle = cells_travelled_along_j_axis_to_exit_ray_start_tile + (j_steps_taken - one(I)) * tile_length
         height_ray_triangle = (width_ray_triangle * abs_i_ray_direction) // abs_j_ray_direction
         rounded_height_ray_triangle = round(I, height_ray_triangle, RoundDown)
         j_ray_stop = j_ray_start + sign_j_ray_direction * width_ray_triangle
-        i_ray_stop_high = i_ray_hit_tile * height_tile
-        i_ray_stop_low = i_ray_stop_high - height_tile + one(I)
+        i_ray_stop_high = i_ray_hit_tile * tile_length
+        i_ray_stop_low = i_ray_stop_high - tile_length + one(I)
         i_ray_stop = clamp(i_ray_start + sign_i_ray_direction * rounded_height_ray_triangle, i_ray_stop_low, i_ray_stop_high)
     else
         i_ray_stop = i_ray_start

--- a/src/RayCaster.jl
+++ b/src/RayCaster.jl
@@ -13,6 +13,8 @@ end
 function cast_ray(obstacle_tile_map::AbstractArray{Bool, 2}, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_start_tile, j_ray_start_tile, i_ray_direction, j_ray_direction, max_steps)
     I = typeof(i_ray_start_cell)
 
+    @assert !(iszero(i_ray_direction) && iszero(j_ray_direction))
+
     if i_ray_direction < zero(I)
         i_tile_step_size = -one(I)
         cells_travelled_along_i_axis_to_exit_ray_start_tile = (i_ray_start_cell - (i_ray_start_tile - one(I)) * cells_per_tile_1d)

--- a/src/RayCaster.jl
+++ b/src/RayCaster.jl
@@ -80,16 +80,23 @@ function cast_ray(obstacle_tile_map::AbstractArray{Bool, 2}, cells_per_tile_1d, 
     if hit_dimension == 1
         height_ray_triangle = cells_travelled_along_i_axis_to_exit_ray_start_tile + (i_steps_taken - one(I)) * cells_per_tile_1d
         width_ray_triangle = div(height_ray_triangle * width_ray_direction_triangle, height_ray_direction_triangle, RoundNearest)
+        i_ray_stop_cell = i_ray_start_cell + sign_i_ray_direction * (height_ray_triangle - one(I))
+        j_ray_stop_cell_high = j_ray_hit_tile * cells_per_tile_1d
+        j_ray_stop_cell_low = j_ray_stop_cell_high - cells_per_tile_1d + one(I)
+        j_ray_stop_cell = clamp(j_ray_start_cell + sign_j_ray_direction * (width_ray_triangle - one(I)), j_ray_stop_cell_low, j_ray_stop_cell_high)
     elseif hit_dimension == 2
         width_ray_triangle = cells_travelled_along_j_axis_to_exit_ray_start_tile + (j_steps_taken - one(I)) * cells_per_tile_1d
         height_ray_triangle = div(width_ray_triangle * height_ray_direction_triangle, width_ray_direction_triangle, RoundNearest)
+        j_ray_stop_cell = j_ray_start_cell + sign_j_ray_direction * (width_ray_triangle - one(I))
+        i_ray_stop_cell_high = i_ray_hit_tile * cells_per_tile_1d
+        i_ray_stop_cell_low = i_ray_stop_cell_high - cells_per_tile_1d + one(I)
+        i_ray_stop_cell = clamp(i_ray_start_cell + sign_i_ray_direction * (height_ray_triangle - one(I)), i_ray_stop_cell_low, i_ray_stop_cell_high)
     else
         height_ray_triangle = one(I)
         width_ray_triangle = one(I)
+        i_ray_stop_cell = i_ray_start_cell
+        j_ray_stop_cell = j_ray_start_cell
     end
-
-    i_ray_stop_cell = i_ray_start_cell + sign_i_ray_direction * (height_ray_triangle - one(I))
-    j_ray_stop_cell = j_ray_start_cell + sign_j_ray_direction * (width_ray_triangle - one(I))
 
     return i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension
 end

--- a/src/RayCaster.jl
+++ b/src/RayCaster.jl
@@ -1,55 +1,55 @@
 module RayCaster
 
-function cast_ray(obstacle_tile_map::AbstractArray{Bool, 2}, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+function cast_ray(obstacle_tile_map::AbstractArray{Bool, 2}, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
     @assert !(iszero(i_ray_direction) && iszero(j_ray_direction))
 
-    i_ray_start_tile = fld1(i_ray_start, cells_per_tile_1d)
-    j_ray_start_tile = fld1(j_ray_start, cells_per_tile_1d)
+    i_ray_start_tile = fld1(i_ray_start, height_tile)
+    j_ray_start_tile = fld1(j_ray_start, height_tile)
 
-    return cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_start_tile, j_ray_start_tile, i_ray_direction, j_ray_direction, max_steps)
+    return cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_start_tile, j_ray_start_tile, i_ray_direction, j_ray_direction, max_steps)
 end
 
-function cast_ray(obstacle_tile_map::AbstractArray{Bool, 2}, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_start_tile, j_ray_start_tile, i_ray_direction, j_ray_direction, max_steps)
+function cast_ray(obstacle_tile_map::AbstractArray{Bool, 2}, height_tile, i_ray_start, j_ray_start, i_ray_start_tile, j_ray_start_tile, i_ray_direction, j_ray_direction, max_steps)
     I = typeof(i_ray_start)
 
     if i_ray_direction < zero(I)
         i_tile_step_size = -one(I)
-        cells_travelled_along_i_axis_to_exit_ray_start_tile = (i_ray_start - (i_ray_start_tile - one(I)) * cells_per_tile_1d - one(I))
+        cells_travelled_along_i_axis_to_exit_ray_start_tile = (i_ray_start - (i_ray_start_tile - one(I)) * height_tile - one(I))
         sign_i_ray_direction = -one(I)
         abs_i_ray_direction = -i_ray_direction
     elseif i_ray_direction > zero(I)
         i_tile_step_size = one(I)
-        cells_travelled_along_i_axis_to_exit_ray_start_tile = (i_ray_start_tile * cells_per_tile_1d + one(I)- i_ray_start)
+        cells_travelled_along_i_axis_to_exit_ray_start_tile = (i_ray_start_tile * height_tile + one(I)- i_ray_start)
         sign_i_ray_direction = one(I)
         abs_i_ray_direction = i_ray_direction
     else
         i_tile_step_size = zero(I)
-        cells_travelled_along_i_axis_to_exit_ray_start_tile = (i_ray_start_tile * cells_per_tile_1d + one(I) - i_ray_start)
+        cells_travelled_along_i_axis_to_exit_ray_start_tile = (i_ray_start_tile * height_tile + one(I) - i_ray_start)
         sign_i_ray_direction = i_ray_direction
         abs_i_ray_direction = i_ray_direction
     end
 
     if j_ray_direction < zero(I)
         j_tile_step_size = -one(I)
-        cells_travelled_along_j_axis_to_exit_ray_start_tile = (j_ray_start - (j_ray_start_tile - one(I)) * cells_per_tile_1d - one(I))
+        cells_travelled_along_j_axis_to_exit_ray_start_tile = (j_ray_start - (j_ray_start_tile - one(I)) * height_tile - one(I))
         sign_j_ray_direction = -one(I)
         abs_j_ray_direction = -j_ray_direction
     elseif j_ray_direction > zero(I)
         j_tile_step_size = one(I)
-        cells_travelled_along_j_axis_to_exit_ray_start_tile = (j_ray_start_tile * cells_per_tile_1d + one(I)- j_ray_start)
+        cells_travelled_along_j_axis_to_exit_ray_start_tile = (j_ray_start_tile * height_tile + one(I)- j_ray_start)
         sign_j_ray_direction = one(I)
         abs_j_ray_direction = j_ray_direction
     else
         j_tile_step_size = zero(I)
-        cells_travelled_along_j_axis_to_exit_ray_start_tile = (j_ray_start_tile * cells_per_tile_1d + one(I)- j_ray_start)
+        cells_travelled_along_j_axis_to_exit_ray_start_tile = (j_ray_start_tile * height_tile + one(I)- j_ray_start)
         sign_j_ray_direction = j_ray_direction
         abs_j_ray_direction = j_ray_direction
     end
 
     height_ray_direction_triangle = abs_i_ray_direction + one(I)
     width_ray_direction_triangle = abs_j_ray_direction + one(I)
-    scaled_increase_in_ray_length_per_tile_travelled_along_i_axis = cells_per_tile_1d * abs_j_ray_direction
-    scaled_increase_in_ray_length_per_tile_travelled_along_j_axis = cells_per_tile_1d * abs_i_ray_direction
+    scaled_increase_in_ray_length_per_tile_travelled_along_i_axis = height_tile * abs_j_ray_direction
+    scaled_increase_in_ray_length_per_tile_travelled_along_j_axis = height_tile * abs_i_ray_direction
 
     scaled_ray_length_when_traveling_along_i_axis = cells_travelled_along_i_axis_to_exit_ray_start_tile * abs_j_ray_direction
     scaled_ray_length_when_traveling_along_j_axis = cells_travelled_along_j_axis_to_exit_ray_start_tile * abs_i_ray_direction
@@ -75,20 +75,20 @@ function cast_ray(obstacle_tile_map::AbstractArray{Bool, 2}, cells_per_tile_1d, 
     end
 
     if hit_dimension == 1
-        height_ray_triangle = cells_travelled_along_i_axis_to_exit_ray_start_tile + (i_steps_taken - one(I)) * cells_per_tile_1d
+        height_ray_triangle = cells_travelled_along_i_axis_to_exit_ray_start_tile + (i_steps_taken - one(I)) * height_tile
         width_ray_triangle = (height_ray_triangle * abs_j_ray_direction) // abs_i_ray_direction
         rounded_width_ray_triangle = round(I, width_ray_triangle, RoundDown)
         i_ray_stop = i_ray_start + sign_i_ray_direction * height_ray_triangle
-        j_ray_stop_high = j_ray_hit_tile * cells_per_tile_1d
-        j_ray_stop_low = j_ray_stop_high - cells_per_tile_1d + one(I)
+        j_ray_stop_high = j_ray_hit_tile * height_tile
+        j_ray_stop_low = j_ray_stop_high - height_tile + one(I)
         j_ray_stop = clamp(j_ray_start + sign_j_ray_direction * rounded_width_ray_triangle, j_ray_stop_low, j_ray_stop_high)
     elseif hit_dimension == 2
-        width_ray_triangle = cells_travelled_along_j_axis_to_exit_ray_start_tile + (j_steps_taken - one(I)) * cells_per_tile_1d
+        width_ray_triangle = cells_travelled_along_j_axis_to_exit_ray_start_tile + (j_steps_taken - one(I)) * height_tile
         height_ray_triangle = (width_ray_triangle * abs_i_ray_direction) // abs_j_ray_direction
         rounded_height_ray_triangle = round(I, height_ray_triangle, RoundDown)
         j_ray_stop = j_ray_start + sign_j_ray_direction * width_ray_triangle
-        i_ray_stop_high = i_ray_hit_tile * cells_per_tile_1d
-        i_ray_stop_low = i_ray_stop_high - cells_per_tile_1d + one(I)
+        i_ray_stop_high = i_ray_hit_tile * height_tile
+        i_ray_stop_low = i_ray_stop_high - height_tile + one(I)
         i_ray_stop = clamp(i_ray_start + sign_i_ray_direction * rounded_height_ray_triangle, i_ray_stop_low, i_ray_stop_high)
     else
         i_ray_stop = i_ray_start

--- a/src/RayCaster.jl
+++ b/src/RayCaster.jl
@@ -1,11 +1,8 @@
 module RayCaster
 
-cell_coordinate_to_tile_coordinate(i_cell, cells_per_tile_1d) = (i_cell - one(i_cell)) ÷ cells_per_tile_1d + one(i_cell)
-
-cell_to_tile(i_cell, j_cell, cells_per_tile_1d) = (cell_coordinate_to_tile_coordinate(i_cell, cells_per_tile_1d), cell_coordinate_to_tile_coordinate(j_cell, cells_per_tile_1d))
-
 function cast_ray(obstacle_tile_map::AbstractArray{Bool, 2}, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-    i_ray_start_tile, j_ray_start_tile = cell_to_tile(i_ray_start_cell, j_ray_start_cell, cells_per_tile_1d)
+    i_ray_start_tile = fld1(i_ray_start_cell, cells_per_tile_1d)
+    j_ray_start_tile = fld1(j_ray_start_cell, cells_per_tile_1d)
 
     return cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_start_tile, j_ray_start_tile, i_ray_direction, j_ray_direction, max_steps)
 end

--- a/src/RayCaster.jl
+++ b/src/RayCaster.jl
@@ -1,47 +1,47 @@
 module RayCaster
 
-function cast_ray(obstacle_tile_map::AbstractArray{Bool, 2}, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+function cast_ray(obstacle_tile_map::AbstractArray{Bool, 2}, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
     @assert !(iszero(i_ray_direction) && iszero(j_ray_direction))
 
-    i_ray_start_tile = fld1(i_ray_start_cell, cells_per_tile_1d)
-    j_ray_start_tile = fld1(j_ray_start_cell, cells_per_tile_1d)
+    i_ray_start_tile = fld1(i_ray_start, cells_per_tile_1d)
+    j_ray_start_tile = fld1(j_ray_start, cells_per_tile_1d)
 
-    return cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_start_tile, j_ray_start_tile, i_ray_direction, j_ray_direction, max_steps)
+    return cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_start_tile, j_ray_start_tile, i_ray_direction, j_ray_direction, max_steps)
 end
 
-function cast_ray(obstacle_tile_map::AbstractArray{Bool, 2}, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_start_tile, j_ray_start_tile, i_ray_direction, j_ray_direction, max_steps)
-    I = typeof(i_ray_start_cell)
+function cast_ray(obstacle_tile_map::AbstractArray{Bool, 2}, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_start_tile, j_ray_start_tile, i_ray_direction, j_ray_direction, max_steps)
+    I = typeof(i_ray_start)
 
     if i_ray_direction < zero(I)
         i_tile_step_size = -one(I)
-        cells_travelled_along_i_axis_to_exit_ray_start_tile = (i_ray_start_cell - (i_ray_start_tile - one(I)) * cells_per_tile_1d - one(I))
+        cells_travelled_along_i_axis_to_exit_ray_start_tile = (i_ray_start - (i_ray_start_tile - one(I)) * cells_per_tile_1d - one(I))
         sign_i_ray_direction = -one(I)
         abs_i_ray_direction = -i_ray_direction
     elseif i_ray_direction > zero(I)
         i_tile_step_size = one(I)
-        cells_travelled_along_i_axis_to_exit_ray_start_tile = (i_ray_start_tile * cells_per_tile_1d + one(I)- i_ray_start_cell)
+        cells_travelled_along_i_axis_to_exit_ray_start_tile = (i_ray_start_tile * cells_per_tile_1d + one(I)- i_ray_start)
         sign_i_ray_direction = one(I)
         abs_i_ray_direction = i_ray_direction
     else
         i_tile_step_size = zero(I)
-        cells_travelled_along_i_axis_to_exit_ray_start_tile = (i_ray_start_tile * cells_per_tile_1d + one(I) - i_ray_start_cell)
+        cells_travelled_along_i_axis_to_exit_ray_start_tile = (i_ray_start_tile * cells_per_tile_1d + one(I) - i_ray_start)
         sign_i_ray_direction = i_ray_direction
         abs_i_ray_direction = i_ray_direction
     end
 
     if j_ray_direction < zero(I)
         j_tile_step_size = -one(I)
-        cells_travelled_along_j_axis_to_exit_ray_start_tile = (j_ray_start_cell - (j_ray_start_tile - one(I)) * cells_per_tile_1d - one(I))
+        cells_travelled_along_j_axis_to_exit_ray_start_tile = (j_ray_start - (j_ray_start_tile - one(I)) * cells_per_tile_1d - one(I))
         sign_j_ray_direction = -one(I)
         abs_j_ray_direction = -j_ray_direction
     elseif j_ray_direction > zero(I)
         j_tile_step_size = one(I)
-        cells_travelled_along_j_axis_to_exit_ray_start_tile = (j_ray_start_tile * cells_per_tile_1d + one(I)- j_ray_start_cell)
+        cells_travelled_along_j_axis_to_exit_ray_start_tile = (j_ray_start_tile * cells_per_tile_1d + one(I)- j_ray_start)
         sign_j_ray_direction = one(I)
         abs_j_ray_direction = j_ray_direction
     else
         j_tile_step_size = zero(I)
-        cells_travelled_along_j_axis_to_exit_ray_start_tile = (j_ray_start_tile * cells_per_tile_1d + one(I)- j_ray_start_cell)
+        cells_travelled_along_j_axis_to_exit_ray_start_tile = (j_ray_start_tile * cells_per_tile_1d + one(I)- j_ray_start)
         sign_j_ray_direction = j_ray_direction
         abs_j_ray_direction = j_ray_direction
     end
@@ -78,24 +78,24 @@ function cast_ray(obstacle_tile_map::AbstractArray{Bool, 2}, cells_per_tile_1d, 
         height_ray_triangle = cells_travelled_along_i_axis_to_exit_ray_start_tile + (i_steps_taken - one(I)) * cells_per_tile_1d
         width_ray_triangle = (height_ray_triangle * abs_j_ray_direction) // abs_i_ray_direction
         rounded_width_ray_triangle = round(I, width_ray_triangle, RoundDown)
-        i_ray_stop_cell = i_ray_start_cell + sign_i_ray_direction * height_ray_triangle
-        j_ray_stop_cell_high = j_ray_hit_tile * cells_per_tile_1d
-        j_ray_stop_cell_low = j_ray_stop_cell_high - cells_per_tile_1d + one(I)
-        j_ray_stop_cell = clamp(j_ray_start_cell + sign_j_ray_direction * rounded_width_ray_triangle, j_ray_stop_cell_low, j_ray_stop_cell_high)
+        i_ray_stop = i_ray_start + sign_i_ray_direction * height_ray_triangle
+        j_ray_stop_high = j_ray_hit_tile * cells_per_tile_1d
+        j_ray_stop_low = j_ray_stop_high - cells_per_tile_1d + one(I)
+        j_ray_stop = clamp(j_ray_start + sign_j_ray_direction * rounded_width_ray_triangle, j_ray_stop_low, j_ray_stop_high)
     elseif hit_dimension == 2
         width_ray_triangle = cells_travelled_along_j_axis_to_exit_ray_start_tile + (j_steps_taken - one(I)) * cells_per_tile_1d
         height_ray_triangle = (width_ray_triangle * abs_i_ray_direction) // abs_j_ray_direction
         rounded_height_ray_triangle = round(I, height_ray_triangle, RoundDown)
-        j_ray_stop_cell = j_ray_start_cell + sign_j_ray_direction * width_ray_triangle
-        i_ray_stop_cell_high = i_ray_hit_tile * cells_per_tile_1d
-        i_ray_stop_cell_low = i_ray_stop_cell_high - cells_per_tile_1d + one(I)
-        i_ray_stop_cell = clamp(i_ray_start_cell + sign_i_ray_direction * rounded_height_ray_triangle, i_ray_stop_cell_low, i_ray_stop_cell_high)
+        j_ray_stop = j_ray_start + sign_j_ray_direction * width_ray_triangle
+        i_ray_stop_high = i_ray_hit_tile * cells_per_tile_1d
+        i_ray_stop_low = i_ray_stop_high - cells_per_tile_1d + one(I)
+        i_ray_stop = clamp(i_ray_start + sign_i_ray_direction * rounded_height_ray_triangle, i_ray_stop_low, i_ray_stop_high)
     else
-        i_ray_stop_cell = i_ray_start_cell
-        j_ray_stop_cell = j_ray_start_cell
+        i_ray_stop = i_ray_start
+        j_ray_stop = j_ray_start
     end
 
-    return i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension
+    return i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension
 end
 
 end

--- a/src/RayCaster.jl
+++ b/src/RayCaster.jl
@@ -39,21 +39,21 @@ function cast_ray(obstacle_tile_map::AbstractArray{Bool, 2}, cells_per_tile_1d, 
     scaled_ray_length_when_traveling_along_i_axis = cells_travelled_along_i_axis_to_exit_ray_start_tile * scaled_increase_in_ray_length_per_cell_travelled_along_i_axis
     scaled_ray_length_when_traveling_along_j_axis = cells_travelled_along_j_axis_to_exit_ray_start_tile * scaled_increase_in_ray_length_per_cell_travelled_along_j_axis
 
-    i_ray_stop_tile = i_ray_start_tile
-    j_ray_stop_tile = j_ray_start_tile
+    i_ray_hit_tile = i_ray_start_tile
+    j_ray_hit_tile = j_ray_start_tile
     hit_dimension = 0
     i_steps_taken = zero(I)
     j_steps_taken = zero(I)
 
-    while !obstacle_tile_map[i_ray_stop_tile, j_ray_stop_tile] && i_steps_taken < max_steps && j_steps_taken < max_steps
+    while !obstacle_tile_map[i_ray_hit_tile, j_ray_hit_tile] && i_steps_taken < max_steps && j_steps_taken < max_steps
         if (scaled_ray_length_when_traveling_along_i_axis <= scaled_ray_length_when_traveling_along_j_axis)
             scaled_ray_length_when_traveling_along_i_axis += scaled_increase_in_ray_length_per_tile_travelled_along_i_axis
-            i_ray_stop_tile += i_tile_step_size
+            i_ray_hit_tile += i_tile_step_size
             hit_dimension = 1
             i_steps_taken += one(I)
         else
             scaled_ray_length_when_traveling_along_j_axis += scaled_increase_in_ray_length_per_tile_travelled_along_j_axis
-            j_ray_stop_tile += j_tile_step_size
+            j_ray_hit_tile += j_tile_step_size
             hit_dimension = 2
             j_steps_taken += one(I)
         end
@@ -67,7 +67,7 @@ function cast_ray(obstacle_tile_map::AbstractArray{Bool, 2}, cells_per_tile_1d, 
         signed_perpendicular_distance_to_obstacle = zero(I)
     end
 
-    return i_ray_stop_tile, j_ray_stop_tile, hit_dimension, signed_perpendicular_distance_to_obstacle
+    return i_ray_hit_tile, j_ray_hit_tile, hit_dimension, signed_perpendicular_distance_to_obstacle
 end
 
 end

--- a/src/RayCaster.jl
+++ b/src/RayCaster.jl
@@ -10,6 +10,8 @@ function cast_ray(obstacle_tile_map::AbstractArray{Bool, 2}, height_tile, i_ray_
 end
 
 function cast_ray(obstacle_tile_map::AbstractArray{Bool, 2}, height_tile, i_ray_start, j_ray_start, i_ray_start_tile, j_ray_start_tile, i_ray_direction, j_ray_direction, max_steps)
+    @assert !(iszero(i_ray_direction) && iszero(j_ray_direction))
+
     I = typeof(i_ray_start)
 
     if i_ray_direction < zero(I)

--- a/src/RayCaster.jl
+++ b/src/RayCaster.jl
@@ -1,6 +1,8 @@
 module RayCaster
 
 function cast_ray(obstacle_tile_map::AbstractArray{Bool, 2}, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+    @assert !(iszero(i_ray_direction) && iszero(j_ray_direction))
+
     i_ray_start_tile = fld1(i_ray_start_cell, cells_per_tile_1d)
     j_ray_start_tile = fld1(j_ray_start_cell, cells_per_tile_1d)
 
@@ -9,8 +11,6 @@ end
 
 function cast_ray(obstacle_tile_map::AbstractArray{Bool, 2}, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_start_tile, j_ray_start_tile, i_ray_direction, j_ray_direction, max_steps)
     I = typeof(i_ray_start_cell)
-
-    @assert !(iszero(i_ray_direction) && iszero(j_ray_direction))
 
     if i_ray_direction < zero(I)
         i_tile_step_size = -one(I)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -380,4 +380,205 @@ Test.@testset "RayCaster.jl" begin
             Test.@test hit_dimension == 1
         end
     end
+
+    Test.@testset "cells_per_tile_1d = 1" begin
+        cells_per_tile_1d = convert(I, 1)
+
+        i_ray_start_cell = convert(I, (height_obstacle_tile_map * cells_per_tile_1d) ÷ 2 + 1)
+        j_ray_start_cell = convert(I, (width_obstacle_tile_map * cells_per_tile_1d) ÷ 2 + 1)
+
+        Test.@testset "delta_i = 1, delta_j = 0" begin
+            i_ray_direction = convert(I, 1)
+            j_ray_direction = convert(I, 0)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 4)
+            Test.@test j_ray_stop_cell == convert(I, 3)
+            Test.@test i_ray_hit_tile == convert(I, 5)
+            Test.@test j_ray_hit_tile == convert(I, 3)
+            Test.@test hit_dimension == 1
+        end
+
+        Test.@testset "delta_i = 2, delta_j = 1" begin
+            i_ray_direction = convert(I, 2)
+            j_ray_direction = convert(I, 1)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 4)
+            Test.@test j_ray_stop_cell == convert(I, 4)
+            Test.@test i_ray_hit_tile == convert(I, 5)
+            Test.@test j_ray_hit_tile == convert(I, 4)
+            Test.@test hit_dimension == 1
+        end
+
+        Test.@testset "delta_i = 1, delta_j = 1" begin
+            i_ray_direction = convert(I, 1)
+            j_ray_direction = convert(I, 1)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 4)
+            Test.@test j_ray_stop_cell == convert(I, 4)
+            Test.@test i_ray_hit_tile == convert(I, 5)
+            Test.@test j_ray_hit_tile == convert(I, 4)
+            Test.@test hit_dimension == 1
+        end
+
+        Test.@testset "delta_i = 1, delta_j = 2" begin
+            i_ray_direction = convert(I, 1)
+            j_ray_direction = convert(I, 2)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 4)
+            Test.@test j_ray_stop_cell == convert(I, 4)
+            Test.@test i_ray_hit_tile == convert(I, 4)
+            Test.@test j_ray_hit_tile == convert(I, 5)
+            Test.@test hit_dimension == 2
+        end
+
+        Test.@testset "delta_i = 0, delta_j = 1" begin
+            i_ray_direction = convert(I, 0)
+            j_ray_direction = convert(I, 1)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 3)
+            Test.@test j_ray_stop_cell == convert(I, 4)
+            Test.@test i_ray_hit_tile == convert(I, 3)
+            Test.@test j_ray_hit_tile == convert(I, 5)
+            Test.@test hit_dimension == 2
+        end
+
+        Test.@testset "delta_i = -1, delta_j = 2" begin
+            i_ray_direction = convert(I, -1)
+            j_ray_direction = convert(I, 2)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 2)
+            Test.@test j_ray_stop_cell == convert(I, 4)
+            Test.@test i_ray_hit_tile == convert(I, 2)
+            Test.@test j_ray_hit_tile == convert(I, 5)
+            Test.@test hit_dimension == 2
+        end
+
+        Test.@testset "delta_i = -1, delta_j = 1" begin
+            i_ray_direction = convert(I, -1)
+            j_ray_direction = convert(I, 1)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 2)
+            Test.@test j_ray_stop_cell == convert(I, 4)
+            Test.@test i_ray_hit_tile == convert(I, 1)
+            Test.@test j_ray_hit_tile == convert(I, 4)
+            Test.@test hit_dimension == 1
+        end
+
+        Test.@testset "delta_i = -2, delta_j = 1" begin
+            i_ray_direction = convert(I, -2)
+            j_ray_direction = convert(I, 1)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 2)
+            Test.@test j_ray_stop_cell == convert(I, 4)
+            Test.@test i_ray_hit_tile == convert(I, 1)
+            Test.@test j_ray_hit_tile == convert(I, 4)
+            Test.@test hit_dimension == 1
+        end
+
+        Test.@testset "delta_i = -1, delta_j = 0" begin
+            i_ray_direction = convert(I, -1)
+            j_ray_direction = convert(I, 0)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 2)
+            Test.@test j_ray_stop_cell == convert(I, 3)
+            Test.@test i_ray_hit_tile == convert(I, 1)
+            Test.@test j_ray_hit_tile == convert(I, 3)
+            Test.@test hit_dimension == 1
+        end
+
+        Test.@testset "delta_i = -2, delta_j = -1" begin
+            i_ray_direction = convert(I, -2)
+            j_ray_direction = convert(I, -1)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 2)
+            Test.@test j_ray_stop_cell == convert(I, 2)
+            Test.@test i_ray_hit_tile == convert(I, 1)
+            Test.@test j_ray_hit_tile == convert(I, 2)
+            Test.@test hit_dimension == 1
+        end
+
+        Test.@testset "delta_i = -1, delta_j = -1" begin
+            i_ray_direction = convert(I, -1)
+            j_ray_direction = convert(I, -1)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 2)
+            Test.@test j_ray_stop_cell == convert(I, 2)
+            Test.@test i_ray_hit_tile == convert(I, 1)
+            Test.@test j_ray_hit_tile == convert(I, 2)
+            Test.@test hit_dimension == 1
+        end
+
+        Test.@testset "delta_i = -1, delta_j = -2" begin
+            i_ray_direction = convert(I, -1)
+            j_ray_direction = convert(I, -2)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 2)
+            Test.@test j_ray_stop_cell == convert(I, 2)
+            Test.@test i_ray_hit_tile == convert(I, 2)
+            Test.@test j_ray_hit_tile == convert(I, 1)
+            Test.@test hit_dimension == 2
+        end
+
+        Test.@testset "delta_i = 0, delta_j = -1" begin
+            i_ray_direction = convert(I, 0)
+            j_ray_direction = convert(I, -1)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 3)
+            Test.@test j_ray_stop_cell == convert(I, 2)
+            Test.@test i_ray_hit_tile == convert(I, 3)
+            Test.@test j_ray_hit_tile == convert(I, 1)
+            Test.@test hit_dimension == 2
+        end
+
+        Test.@testset "delta_i = 1, delta_j = -2" begin
+            i_ray_direction = convert(I, 1)
+            j_ray_direction = convert(I, -2)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 4)
+            Test.@test j_ray_stop_cell == convert(I, 2)
+            Test.@test i_ray_hit_tile == convert(I, 4)
+            Test.@test j_ray_hit_tile == convert(I, 1)
+            Test.@test hit_dimension == 2
+        end
+
+        Test.@testset "delta_i = 1, delta_j = -1" begin
+            i_ray_direction = convert(I, 1)
+            j_ray_direction = convert(I, -1)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 4)
+            Test.@test j_ray_stop_cell == convert(I, 2)
+            Test.@test i_ray_hit_tile == convert(I, 5)
+            Test.@test j_ray_hit_tile == convert(I, 2)
+            Test.@test hit_dimension == 1
+        end
+
+        Test.@testset "delta_i = 2, delta_j = -1" begin
+            i_ray_direction = convert(I, 2)
+            j_ray_direction = convert(I, -1)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 4)
+            Test.@test j_ray_stop_cell == convert(I, 2)
+            Test.@test i_ray_hit_tile == convert(I, 5)
+            Test.@test j_ray_hit_tile == convert(I, 2)
+            Test.@test hit_dimension == 1
+        end
+    end
+
+    Test.@testset "starting inside an obstacle tile" begin
+        cells_per_tile_1d = convert(I, 8)
+
+        i_ray_start_cell = convert(I, 3)
+        j_ray_start_cell = convert(I, 4)
+
+        Test.@testset "delta_i = 1, delta_j = 0" begin
+            i_ray_direction = convert(I, 1)
+            j_ray_direction = convert(I, 0)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 3)
+            Test.@test j_ray_stop_cell == convert(I, 4)
+            Test.@test i_ray_hit_tile == convert(I, 1)
+            Test.@test j_ray_hit_tile == convert(I, 1)
+            Test.@test hit_dimension == 0
+        end
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,9 +13,9 @@ Test.@testset "RayCaster.jl" begin
     height_obstacle_tile_map = size(obstacle_tile_map, 1)
     width_obstacle_tile_map = size(obstacle_tile_map, 2)
     max_steps = 1024
+    I = Int
 
-    Test.@testset "Discrete world" begin
-        I = Int
+    Test.@testset "cells_per_tile_1d = 8" begin
         cells_per_tile_1d = convert(I, 8)
 
         i_ray_start_cell = convert(I, height_obstacle_tile_map * cells_per_tile_1d ÷ 2 + 1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,9 +24,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = 0" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 0)
-            i_ray_stop_tile, j_ray_stop_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_tile == convert(I, 5)
-            Test.@test j_ray_stop_tile == convert(I, 3)
+            i_ray_hit_tile, j_ray_hit_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_hit_tile == convert(I, 5)
+            Test.@test j_ray_hit_tile == convert(I, 3)
             Test.@test hit_dimension == 1
             Test.@test signed_perpendicular_distance_to_obstacle == convert(I, 384)
         end
@@ -34,9 +34,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 2, delta_j = 1" begin
             i_ray_direction = convert(I, 2)
             j_ray_direction = convert(I, 1)
-            i_ray_stop_tile, j_ray_stop_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_tile == convert(I, 5)
-            Test.@test j_ray_stop_tile == convert(I, 4)
+            i_ray_hit_tile, j_ray_hit_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_hit_tile == convert(I, 5)
+            Test.@test j_ray_hit_tile == convert(I, 4)
             Test.@test hit_dimension == 1
             Test.@test signed_perpendicular_distance_to_obstacle == convert(I, 384)
         end
@@ -44,9 +44,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = 1" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 1)
-            i_ray_stop_tile, j_ray_stop_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_tile == convert(I, 5)
-            Test.@test j_ray_stop_tile == convert(I, 4)
+            i_ray_hit_tile, j_ray_hit_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_hit_tile == convert(I, 5)
+            Test.@test j_ray_hit_tile == convert(I, 4)
             Test.@test hit_dimension == 1
             Test.@test signed_perpendicular_distance_to_obstacle == convert(I, 384)
         end
@@ -54,9 +54,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = 2" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 2)
-            i_ray_stop_tile, j_ray_stop_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_tile == convert(I, 4)
-            Test.@test j_ray_stop_tile == convert(I, 5)
+            i_ray_hit_tile, j_ray_hit_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_hit_tile == convert(I, 4)
+            Test.@test j_ray_hit_tile == convert(I, 5)
             Test.@test hit_dimension == 2
             Test.@test signed_perpendicular_distance_to_obstacle == convert(I, 384)
         end
@@ -64,9 +64,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 0, delta_j = 1" begin
             i_ray_direction = convert(I, 0)
             j_ray_direction = convert(I, 1)
-            i_ray_stop_tile, j_ray_stop_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_tile == convert(I, 3)
-            Test.@test j_ray_stop_tile == convert(I, 5)
+            i_ray_hit_tile, j_ray_hit_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_hit_tile == convert(I, 3)
+            Test.@test j_ray_hit_tile == convert(I, 5)
             Test.@test hit_dimension == 2
             Test.@test signed_perpendicular_distance_to_obstacle == convert(I, 384)
         end
@@ -74,9 +74,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = 2" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, 2)
-            i_ray_stop_tile, j_ray_stop_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_tile == convert(I, 2)
-            Test.@test j_ray_stop_tile == convert(I, 5)
+            i_ray_hit_tile, j_ray_hit_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_hit_tile == convert(I, 2)
+            Test.@test j_ray_hit_tile == convert(I, 5)
             Test.@test hit_dimension == 2
             Test.@test signed_perpendicular_distance_to_obstacle == convert(I, 384)
         end
@@ -84,9 +84,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = 1" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, 1)
-            i_ray_stop_tile, j_ray_stop_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_tile == convert(I, 2)
-            Test.@test j_ray_stop_tile == convert(I, 5)
+            i_ray_hit_tile, j_ray_hit_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_hit_tile == convert(I, 2)
+            Test.@test j_ray_hit_tile == convert(I, 5)
             Test.@test hit_dimension == 2
             Test.@test signed_perpendicular_distance_to_obstacle == convert(I, 384)
         end
@@ -94,9 +94,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -2, delta_j = 1" begin
             i_ray_direction = convert(I, -2)
             j_ray_direction = convert(I, 1)
-            i_ray_stop_tile, j_ray_stop_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_tile == convert(I, 1)
-            Test.@test j_ray_stop_tile == convert(I, 4)
+            i_ray_hit_tile, j_ray_hit_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_hit_tile == convert(I, 1)
+            Test.@test j_ray_hit_tile == convert(I, 4)
             Test.@test hit_dimension == 1
             Test.@test signed_perpendicular_distance_to_obstacle == convert(I, -385)
         end
@@ -104,9 +104,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = 0" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, 0)
-            i_ray_stop_tile, j_ray_stop_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_tile == convert(I, 1)
-            Test.@test j_ray_stop_tile == convert(I, 3)
+            i_ray_hit_tile, j_ray_hit_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_hit_tile == convert(I, 1)
+            Test.@test j_ray_hit_tile == convert(I, 3)
             Test.@test hit_dimension == 1
             Test.@test signed_perpendicular_distance_to_obstacle == convert(I, -385)
         end
@@ -114,9 +114,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -2, delta_j = -1" begin
             i_ray_direction = convert(I, -2)
             j_ray_direction = convert(I, -1)
-            i_ray_stop_tile, j_ray_stop_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_tile == convert(I, 1)
-            Test.@test j_ray_stop_tile == convert(I, 2)
+            i_ray_hit_tile, j_ray_hit_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_hit_tile == convert(I, 1)
+            Test.@test j_ray_hit_tile == convert(I, 2)
             Test.@test hit_dimension == 1
             Test.@test signed_perpendicular_distance_to_obstacle == convert(I, -385)
         end
@@ -124,9 +124,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = -1" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, -1)
-            i_ray_stop_tile, j_ray_stop_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_tile == convert(I, 1)
-            Test.@test j_ray_stop_tile == convert(I, 2)
+            i_ray_hit_tile, j_ray_hit_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_hit_tile == convert(I, 1)
+            Test.@test j_ray_hit_tile == convert(I, 2)
             Test.@test hit_dimension == 1
             Test.@test signed_perpendicular_distance_to_obstacle == convert(I, -385)
         end
@@ -134,9 +134,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = -2" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, -2)
-            i_ray_stop_tile, j_ray_stop_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_tile == convert(I, 2)
-            Test.@test j_ray_stop_tile == convert(I, 1)
+            i_ray_hit_tile, j_ray_hit_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_hit_tile == convert(I, 2)
+            Test.@test j_ray_hit_tile == convert(I, 1)
             Test.@test hit_dimension == 2
             Test.@test signed_perpendicular_distance_to_obstacle == convert(I, -385)
         end
@@ -144,9 +144,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 0, delta_j = -1" begin
             i_ray_direction = convert(I, 0)
             j_ray_direction = convert(I, -1)
-            i_ray_stop_tile, j_ray_stop_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_tile == convert(I, 3)
-            Test.@test j_ray_stop_tile == convert(I, 1)
+            i_ray_hit_tile, j_ray_hit_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_hit_tile == convert(I, 3)
+            Test.@test j_ray_hit_tile == convert(I, 1)
             Test.@test hit_dimension == 2
             Test.@test signed_perpendicular_distance_to_obstacle == convert(I, -385)
         end
@@ -154,9 +154,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = -2" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, -2)
-            i_ray_stop_tile, j_ray_stop_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_tile == convert(I, 4)
-            Test.@test j_ray_stop_tile == convert(I, 1)
+            i_ray_hit_tile, j_ray_hit_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_hit_tile == convert(I, 4)
+            Test.@test j_ray_hit_tile == convert(I, 1)
             Test.@test hit_dimension == 2
             Test.@test signed_perpendicular_distance_to_obstacle == convert(I, -385)
         end
@@ -164,9 +164,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = -1" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, -1)
-            i_ray_stop_tile, j_ray_stop_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_tile == convert(I, 5)
-            Test.@test j_ray_stop_tile == convert(I, 2)
+            i_ray_hit_tile, j_ray_hit_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_hit_tile == convert(I, 5)
+            Test.@test j_ray_hit_tile == convert(I, 2)
             Test.@test hit_dimension == 1
             Test.@test signed_perpendicular_distance_to_obstacle == convert(I, 384)
         end
@@ -174,9 +174,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 2, delta_j = -1" begin
             i_ray_direction = convert(I, 2)
             j_ray_direction = convert(I, -1)
-            i_ray_stop_tile, j_ray_stop_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_tile == convert(I, 5)
-            Test.@test j_ray_stop_tile == convert(I, 2)
+            i_ray_hit_tile, j_ray_hit_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_hit_tile == convert(I, 5)
+            Test.@test j_ray_hit_tile == convert(I, 2)
             Test.@test hit_dimension == 1
             Test.@test signed_perpendicular_distance_to_obstacle == convert(I, 384)
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,16 +15,16 @@ Test.@testset "RayCaster.jl" begin
     max_steps = 1024
     I = Int
 
-    Test.@testset "cells_per_tile_1d = 8" begin
-        cells_per_tile_1d = convert(I, 8)
+    Test.@testset "height_tile = 8" begin
+        height_tile = convert(I, 8)
 
-        i_ray_start = convert(I, height_obstacle_tile_map * cells_per_tile_1d ÷ 2 + 1)
-        j_ray_start = convert(I, width_obstacle_tile_map * cells_per_tile_1d ÷ 2 + 1)
+        i_ray_start = convert(I, height_obstacle_tile_map * height_tile ÷ 2 + 1)
+        j_ray_start = convert(I, width_obstacle_tile_map * height_tile ÷ 2 + 1)
 
         Test.@testset "delta_i = 1, delta_j = 0" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 0)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 33)
             Test.@test j_ray_stop == convert(I, 21)
             Test.@test i_ray_hit_tile == convert(I, 5)
@@ -35,7 +35,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 2, delta_j = 1" begin
             i_ray_direction = convert(I, 2)
             j_ray_direction = convert(I, 1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 33)
             Test.@test j_ray_stop == convert(I, 27)
             Test.@test i_ray_hit_tile == convert(I, 5)
@@ -46,7 +46,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = 1" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 33)
             Test.@test j_ray_stop == convert(I, 32)
             Test.@test i_ray_hit_tile == convert(I, 5)
@@ -57,7 +57,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = 2" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 2)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 27)
             Test.@test j_ray_stop == convert(I, 33)
             Test.@test i_ray_hit_tile == convert(I, 4)
@@ -68,7 +68,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 0, delta_j = 1" begin
             i_ray_direction = convert(I, 0)
             j_ray_direction = convert(I, 1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 21)
             Test.@test j_ray_stop == convert(I, 33)
             Test.@test i_ray_hit_tile == convert(I, 3)
@@ -79,7 +79,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = 2" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, 2)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 15)
             Test.@test j_ray_stop == convert(I, 33)
             Test.@test i_ray_hit_tile == convert(I, 2)
@@ -90,7 +90,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = 1" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, 1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 9)
             Test.@test j_ray_stop == convert(I, 32)
             Test.@test i_ray_hit_tile == convert(I, 1)
@@ -101,7 +101,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -2, delta_j = 1" begin
             i_ray_direction = convert(I, -2)
             j_ray_direction = convert(I, 1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 9)
             Test.@test j_ray_stop == convert(I, 27)
             Test.@test i_ray_hit_tile == convert(I, 1)
@@ -112,7 +112,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = 0" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, 0)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 9)
             Test.@test j_ray_stop == convert(I, 21)
             Test.@test i_ray_hit_tile == convert(I, 1)
@@ -123,7 +123,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -2, delta_j = -1" begin
             i_ray_direction = convert(I, -2)
             j_ray_direction = convert(I, -1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 9)
             Test.@test j_ray_stop == convert(I, 15)
             Test.@test i_ray_hit_tile == convert(I, 1)
@@ -134,7 +134,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = -1" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, -1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 9)
             Test.@test j_ray_stop == convert(I, 9)
             Test.@test i_ray_hit_tile == convert(I, 1)
@@ -145,7 +145,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = -2" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, -2)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 15)
             Test.@test j_ray_stop == convert(I, 9)
             Test.@test i_ray_hit_tile == convert(I, 2)
@@ -156,7 +156,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 0, delta_j = -1" begin
             i_ray_direction = convert(I, 0)
             j_ray_direction = convert(I, -1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 21)
             Test.@test j_ray_stop == convert(I, 9)
             Test.@test i_ray_hit_tile == convert(I, 3)
@@ -167,7 +167,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = -2" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, -2)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 27)
             Test.@test j_ray_stop == convert(I, 9)
             Test.@test i_ray_hit_tile == convert(I, 4)
@@ -178,7 +178,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = -1" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, -1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 33)
             Test.@test j_ray_stop == convert(I, 9)
             Test.@test i_ray_hit_tile == convert(I, 5)
@@ -189,7 +189,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 2, delta_j = -1" begin
             i_ray_direction = convert(I, 2)
             j_ray_direction = convert(I, -1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 33)
             Test.@test j_ray_stop == convert(I, 15)
             Test.@test i_ray_hit_tile == convert(I, 5)
@@ -198,16 +198,16 @@ Test.@testset "RayCaster.jl" begin
         end
     end
 
-    Test.@testset "cells_per_tile_1d = 9" begin
-        cells_per_tile_1d = convert(I, 9)
+    Test.@testset "height_tile = 9" begin
+        height_tile = convert(I, 9)
 
-        i_ray_start = convert(I, (height_obstacle_tile_map * cells_per_tile_1d) ÷ 2 + 1)
-        j_ray_start = convert(I, (width_obstacle_tile_map * cells_per_tile_1d) ÷ 2 + 1)
+        i_ray_start = convert(I, (height_obstacle_tile_map * height_tile) ÷ 2 + 1)
+        j_ray_start = convert(I, (width_obstacle_tile_map * height_tile) ÷ 2 + 1)
 
         Test.@testset "delta_i = 1, delta_j = 0" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 0)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 37)
             Test.@test j_ray_stop == convert(I, 23)
             Test.@test i_ray_hit_tile == convert(I, 5)
@@ -218,7 +218,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 2, delta_j = 1" begin
             i_ray_direction = convert(I, 2)
             j_ray_direction = convert(I, 1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 37)
             Test.@test j_ray_stop == convert(I, 30)
             Test.@test i_ray_hit_tile == convert(I, 5)
@@ -229,7 +229,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = 1" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 37)
             Test.@test j_ray_stop == convert(I, 36)
             Test.@test i_ray_hit_tile == convert(I, 5)
@@ -240,7 +240,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = 2" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 2)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 30)
             Test.@test j_ray_stop == convert(I, 37)
             Test.@test i_ray_hit_tile == convert(I, 4)
@@ -251,7 +251,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 0, delta_j = 1" begin
             i_ray_direction = convert(I, 0)
             j_ray_direction = convert(I, 1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 23)
             Test.@test j_ray_stop == convert(I, 37)
             Test.@test i_ray_hit_tile == convert(I, 3)
@@ -262,7 +262,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = 2" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, 2)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 16)
             Test.@test j_ray_stop == convert(I, 37)
             Test.@test i_ray_hit_tile == convert(I, 2)
@@ -273,7 +273,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = 1" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, 1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 10)
             Test.@test j_ray_stop == convert(I, 36)
             Test.@test i_ray_hit_tile == convert(I, 1)
@@ -284,7 +284,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -2, delta_j = 1" begin
             i_ray_direction = convert(I, -2)
             j_ray_direction = convert(I, 1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 10)
             Test.@test j_ray_stop == convert(I, 29)
             Test.@test i_ray_hit_tile == convert(I, 1)
@@ -295,7 +295,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = 0" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, 0)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 10)
             Test.@test j_ray_stop == convert(I, 23)
             Test.@test i_ray_hit_tile == convert(I, 1)
@@ -306,7 +306,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -2, delta_j = -1" begin
             i_ray_direction = convert(I, -2)
             j_ray_direction = convert(I, -1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 10)
             Test.@test j_ray_stop == convert(I, 17)
             Test.@test i_ray_hit_tile == convert(I, 1)
@@ -317,7 +317,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = -1" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, -1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 10)
             Test.@test j_ray_stop == convert(I, 10)
             Test.@test i_ray_hit_tile == convert(I, 1)
@@ -328,7 +328,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = -2" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, -2)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 17)
             Test.@test j_ray_stop == convert(I, 10)
             Test.@test i_ray_hit_tile == convert(I, 2)
@@ -339,7 +339,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 0, delta_j = -1" begin
             i_ray_direction = convert(I, 0)
             j_ray_direction = convert(I, -1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 23)
             Test.@test j_ray_stop == convert(I, 10)
             Test.@test i_ray_hit_tile == convert(I, 3)
@@ -350,7 +350,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = -2" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, -2)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 29)
             Test.@test j_ray_stop == convert(I, 10)
             Test.@test i_ray_hit_tile == convert(I, 4)
@@ -361,7 +361,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = -1" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, -1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 36)
             Test.@test j_ray_stop == convert(I, 10)
             Test.@test i_ray_hit_tile == convert(I, 4)
@@ -372,7 +372,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 2, delta_j = -1" begin
             i_ray_direction = convert(I, 2)
             j_ray_direction = convert(I, -1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 37)
             Test.@test j_ray_stop == convert(I, 16)
             Test.@test i_ray_hit_tile == convert(I, 5)
@@ -381,16 +381,16 @@ Test.@testset "RayCaster.jl" begin
         end
     end
 
-    Test.@testset "cells_per_tile_1d = 1" begin
-        cells_per_tile_1d = convert(I, 1)
+    Test.@testset "height_tile = 1" begin
+        height_tile = convert(I, 1)
 
-        i_ray_start = convert(I, (height_obstacle_tile_map * cells_per_tile_1d) ÷ 2 + 1)
-        j_ray_start = convert(I, (width_obstacle_tile_map * cells_per_tile_1d) ÷ 2 + 1)
+        i_ray_start = convert(I, (height_obstacle_tile_map * height_tile) ÷ 2 + 1)
+        j_ray_start = convert(I, (width_obstacle_tile_map * height_tile) ÷ 2 + 1)
 
         Test.@testset "delta_i = 1, delta_j = 0" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 0)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 5)
             Test.@test j_ray_stop == convert(I, 3)
             Test.@test i_ray_hit_tile == convert(I, 5)
@@ -401,7 +401,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 2, delta_j = 1" begin
             i_ray_direction = convert(I, 2)
             j_ray_direction = convert(I, 1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 5)
             Test.@test j_ray_stop == convert(I, 3)
             Test.@test i_ray_hit_tile == convert(I, 5)
@@ -412,7 +412,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = 1" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 5)
             Test.@test j_ray_stop == convert(I, 4)
             Test.@test i_ray_hit_tile == convert(I, 5)
@@ -423,7 +423,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = 2" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 2)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 4)
             Test.@test j_ray_stop == convert(I, 5)
             Test.@test i_ray_hit_tile == convert(I, 4)
@@ -434,7 +434,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 0, delta_j = 1" begin
             i_ray_direction = convert(I, 0)
             j_ray_direction = convert(I, 1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 3)
             Test.@test j_ray_stop == convert(I, 5)
             Test.@test i_ray_hit_tile == convert(I, 3)
@@ -445,7 +445,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = 2" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, 2)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 2)
             Test.@test j_ray_stop == convert(I, 4)
             Test.@test i_ray_hit_tile == convert(I, 1)
@@ -456,7 +456,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = 1" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, 1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 2)
             Test.@test j_ray_stop == convert(I, 3)
             Test.@test i_ray_hit_tile == convert(I, 1)
@@ -467,7 +467,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -2, delta_j = 1" begin
             i_ray_direction = convert(I, -2)
             j_ray_direction = convert(I, 1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 2)
             Test.@test j_ray_stop == convert(I, 3)
             Test.@test i_ray_hit_tile == convert(I, 1)
@@ -478,7 +478,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = 0" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, 0)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 2)
             Test.@test j_ray_stop == convert(I, 3)
             Test.@test i_ray_hit_tile == convert(I, 1)
@@ -489,7 +489,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -2, delta_j = -1" begin
             i_ray_direction = convert(I, -2)
             j_ray_direction = convert(I, -1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 2)
             Test.@test j_ray_stop == convert(I, 2)
             Test.@test i_ray_hit_tile == convert(I, 1)
@@ -500,7 +500,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = -1" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, -1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 2)
             Test.@test j_ray_stop == convert(I, 2)
             Test.@test i_ray_hit_tile == convert(I, 1)
@@ -511,7 +511,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = -2" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, -2)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 2)
             Test.@test j_ray_stop == convert(I, 2)
             Test.@test i_ray_hit_tile == convert(I, 2)
@@ -522,7 +522,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 0, delta_j = -1" begin
             i_ray_direction = convert(I, 0)
             j_ray_direction = convert(I, -1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 3)
             Test.@test j_ray_stop == convert(I, 2)
             Test.@test i_ray_hit_tile == convert(I, 3)
@@ -533,7 +533,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = -2" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, -2)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 3)
             Test.@test j_ray_stop == convert(I, 2)
             Test.@test i_ray_hit_tile == convert(I, 3)
@@ -544,7 +544,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = -1" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, -1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 4)
             Test.@test j_ray_stop == convert(I, 2)
             Test.@test i_ray_hit_tile == convert(I, 4)
@@ -555,7 +555,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 2, delta_j = -1" begin
             i_ray_direction = convert(I, 2)
             j_ray_direction = convert(I, -1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 5)
             Test.@test j_ray_stop == convert(I, 2)
             Test.@test i_ray_hit_tile == convert(I, 5)
@@ -565,7 +565,7 @@ Test.@testset "RayCaster.jl" begin
     end
 
     Test.@testset "starting inside an obstacle tile" begin
-        cells_per_tile_1d = convert(I, 8)
+        height_tile = convert(I, 8)
 
         i_ray_start = convert(I, 3)
         j_ray_start = convert(I, 4)
@@ -573,7 +573,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = 0" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 0)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 3)
             Test.@test j_ray_stop == convert(I, 4)
             Test.@test i_ray_hit_tile == convert(I, 1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,7 +16,7 @@ Test.@testset "RayCaster.jl" begin
 
     Test.@testset "Discrete world" begin
         I = Int
-        cells_per_tile_1d = convert(I, 256)
+        cells_per_tile_1d = convert(I, 8)
 
         i_ray_start_cell = convert(I, height_obstacle_tile_map * cells_per_tile_1d ÷ 2 + 1)
         j_ray_start_cell = convert(I, width_obstacle_tile_map * cells_per_tile_1d ÷ 2 + 1)
@@ -24,161 +24,177 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = 0" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 0)
-            i_ray_hit_tile, j_ray_hit_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 32)
+            Test.@test j_ray_stop_cell == convert(I, 21)
             Test.@test i_ray_hit_tile == convert(I, 5)
             Test.@test j_ray_hit_tile == convert(I, 3)
             Test.@test hit_dimension == 1
-            Test.@test signed_perpendicular_distance_to_obstacle == convert(I, 384)
         end
 
         Test.@testset "delta_i = 2, delta_j = 1" begin
             i_ray_direction = convert(I, 2)
             j_ray_direction = convert(I, 1)
-            i_ray_hit_tile, j_ray_hit_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 32)
+            Test.@test j_ray_stop_cell == convert(I, 28)
             Test.@test i_ray_hit_tile == convert(I, 5)
             Test.@test j_ray_hit_tile == convert(I, 4)
             Test.@test hit_dimension == 1
-            Test.@test signed_perpendicular_distance_to_obstacle == convert(I, 384)
         end
 
         Test.@testset "delta_i = 1, delta_j = 1" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 1)
-            i_ray_hit_tile, j_ray_hit_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 32)
+            Test.@test j_ray_stop_cell == convert(I, 32)
             Test.@test i_ray_hit_tile == convert(I, 5)
             Test.@test j_ray_hit_tile == convert(I, 4)
             Test.@test hit_dimension == 1
-            Test.@test signed_perpendicular_distance_to_obstacle == convert(I, 384)
         end
 
         Test.@testset "delta_i = 1, delta_j = 2" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 2)
-            i_ray_hit_tile, j_ray_hit_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 28)
+            Test.@test j_ray_stop_cell == convert(I, 32)
             Test.@test i_ray_hit_tile == convert(I, 4)
             Test.@test j_ray_hit_tile == convert(I, 5)
             Test.@test hit_dimension == 2
-            Test.@test signed_perpendicular_distance_to_obstacle == convert(I, 384)
         end
 
         Test.@testset "delta_i = 0, delta_j = 1" begin
             i_ray_direction = convert(I, 0)
             j_ray_direction = convert(I, 1)
-            i_ray_hit_tile, j_ray_hit_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 21)
+            Test.@test j_ray_stop_cell == convert(I, 32)
             Test.@test i_ray_hit_tile == convert(I, 3)
             Test.@test j_ray_hit_tile == convert(I, 5)
             Test.@test hit_dimension == 2
-            Test.@test signed_perpendicular_distance_to_obstacle == convert(I, 384)
         end
 
         Test.@testset "delta_i = -1, delta_j = 2" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, 2)
-            i_ray_hit_tile, j_ray_hit_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 14)
+            Test.@test j_ray_stop_cell == convert(I, 32)
             Test.@test i_ray_hit_tile == convert(I, 2)
             Test.@test j_ray_hit_tile == convert(I, 5)
             Test.@test hit_dimension == 2
-            Test.@test signed_perpendicular_distance_to_obstacle == convert(I, 384)
         end
 
         Test.@testset "delta_i = -1, delta_j = 1" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, 1)
-            i_ray_hit_tile, j_ray_hit_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 10)
+            Test.@test j_ray_stop_cell == convert(I, 32)
             Test.@test i_ray_hit_tile == convert(I, 2)
             Test.@test j_ray_hit_tile == convert(I, 5)
             Test.@test hit_dimension == 2
-            Test.@test signed_perpendicular_distance_to_obstacle == convert(I, 384)
         end
 
         Test.@testset "delta_i = -2, delta_j = 1" begin
             i_ray_direction = convert(I, -2)
             j_ray_direction = convert(I, 1)
-            i_ray_hit_tile, j_ray_hit_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 9)
+            Test.@test j_ray_stop_cell == convert(I, 29)
             Test.@test i_ray_hit_tile == convert(I, 1)
             Test.@test j_ray_hit_tile == convert(I, 4)
             Test.@test hit_dimension == 1
-            Test.@test signed_perpendicular_distance_to_obstacle == convert(I, -385)
         end
 
         Test.@testset "delta_i = -1, delta_j = 0" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, 0)
-            i_ray_hit_tile, j_ray_hit_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 9)
+            Test.@test j_ray_stop_cell == convert(I, 21)
             Test.@test i_ray_hit_tile == convert(I, 1)
             Test.@test j_ray_hit_tile == convert(I, 3)
             Test.@test hit_dimension == 1
-            Test.@test signed_perpendicular_distance_to_obstacle == convert(I, -385)
         end
 
         Test.@testset "delta_i = -2, delta_j = -1" begin
             i_ray_direction = convert(I, -2)
             j_ray_direction = convert(I, -1)
-            i_ray_hit_tile, j_ray_hit_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 9)
+            Test.@test j_ray_stop_cell == convert(I, 13)
             Test.@test i_ray_hit_tile == convert(I, 1)
             Test.@test j_ray_hit_tile == convert(I, 2)
             Test.@test hit_dimension == 1
-            Test.@test signed_perpendicular_distance_to_obstacle == convert(I, -385)
         end
 
         Test.@testset "delta_i = -1, delta_j = -1" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, -1)
-            i_ray_hit_tile, j_ray_hit_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 9)
+            Test.@test j_ray_stop_cell == convert(I, 9)
             Test.@test i_ray_hit_tile == convert(I, 1)
             Test.@test j_ray_hit_tile == convert(I, 2)
             Test.@test hit_dimension == 1
-            Test.@test signed_perpendicular_distance_to_obstacle == convert(I, -385)
         end
 
         Test.@testset "delta_i = -1, delta_j = -2" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, -2)
-            i_ray_hit_tile, j_ray_hit_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 13)
+            Test.@test j_ray_stop_cell == convert(I, 9)
             Test.@test i_ray_hit_tile == convert(I, 2)
             Test.@test j_ray_hit_tile == convert(I, 1)
             Test.@test hit_dimension == 2
-            Test.@test signed_perpendicular_distance_to_obstacle == convert(I, -385)
         end
 
         Test.@testset "delta_i = 0, delta_j = -1" begin
             i_ray_direction = convert(I, 0)
             j_ray_direction = convert(I, -1)
-            i_ray_hit_tile, j_ray_hit_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 21)
+            Test.@test j_ray_stop_cell == convert(I, 9)
             Test.@test i_ray_hit_tile == convert(I, 3)
             Test.@test j_ray_hit_tile == convert(I, 1)
             Test.@test hit_dimension == 2
-            Test.@test signed_perpendicular_distance_to_obstacle == convert(I, -385)
         end
 
         Test.@testset "delta_i = 1, delta_j = -2" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, -2)
-            i_ray_hit_tile, j_ray_hit_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 29)
+            Test.@test j_ray_stop_cell == convert(I, 9)
             Test.@test i_ray_hit_tile == convert(I, 4)
             Test.@test j_ray_hit_tile == convert(I, 1)
             Test.@test hit_dimension == 2
-            Test.@test signed_perpendicular_distance_to_obstacle == convert(I, -385)
         end
 
         Test.@testset "delta_i = 1, delta_j = -1" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, -1)
-            i_ray_hit_tile, j_ray_hit_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 32)
+            Test.@test j_ray_stop_cell == convert(I, 10)
             Test.@test i_ray_hit_tile == convert(I, 5)
             Test.@test j_ray_hit_tile == convert(I, 2)
             Test.@test hit_dimension == 1
-            Test.@test signed_perpendicular_distance_to_obstacle == convert(I, 384)
         end
 
         Test.@testset "delta_i = 2, delta_j = -1" begin
             i_ray_direction = convert(I, 2)
             j_ray_direction = convert(I, -1)
-            i_ray_hit_tile, j_ray_hit_tile, hit_dimension, signed_perpendicular_distance_to_obstacle = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 32)
+            Test.@test j_ray_stop_cell == convert(I, 14)
             Test.@test i_ray_hit_tile == convert(I, 5)
             Test.@test j_ray_hit_tile == convert(I, 2)
             Test.@test hit_dimension == 1
-            Test.@test signed_perpendicular_distance_to_obstacle == convert(I, 384)
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,16 +15,16 @@ Test.@testset "RayCaster.jl" begin
     max_steps = 1024
     I = Int
 
-    Test.@testset "height_tile = 8" begin
-        height_tile = convert(I, 8)
+    Test.@testset "tile_length = 8" begin
+        tile_length = convert(I, 8)
 
-        i_ray_start = convert(I, (height_obstacle_tile_map * height_tile) ÷ 2 + 1)
-        j_ray_start = convert(I, (width_obstacle_tile_map * height_tile) ÷ 2 + 1)
+        i_ray_start = convert(I, (height_obstacle_tile_map * tile_length) ÷ 2 + 1)
+        j_ray_start = convert(I, (width_obstacle_tile_map * tile_length) ÷ 2 + 1)
 
         Test.@testset "delta_i = 1, delta_j = 0" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 0)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 33)
             Test.@test j_ray_stop == convert(I, 21)
             Test.@test i_ray_hit_tile == convert(I, 5)
@@ -35,7 +35,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 2, delta_j = 1" begin
             i_ray_direction = convert(I, 2)
             j_ray_direction = convert(I, 1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 33)
             Test.@test j_ray_stop == convert(I, 27)
             Test.@test i_ray_hit_tile == convert(I, 5)
@@ -46,7 +46,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = 1" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 33)
             Test.@test j_ray_stop == convert(I, 32)
             Test.@test i_ray_hit_tile == convert(I, 5)
@@ -57,7 +57,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = 2" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 2)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 27)
             Test.@test j_ray_stop == convert(I, 33)
             Test.@test i_ray_hit_tile == convert(I, 4)
@@ -68,7 +68,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 0, delta_j = 1" begin
             i_ray_direction = convert(I, 0)
             j_ray_direction = convert(I, 1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 21)
             Test.@test j_ray_stop == convert(I, 33)
             Test.@test i_ray_hit_tile == convert(I, 3)
@@ -79,7 +79,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = 2" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, 2)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 15)
             Test.@test j_ray_stop == convert(I, 33)
             Test.@test i_ray_hit_tile == convert(I, 2)
@@ -90,7 +90,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = 1" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, 1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 9)
             Test.@test j_ray_stop == convert(I, 32)
             Test.@test i_ray_hit_tile == convert(I, 1)
@@ -101,7 +101,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -2, delta_j = 1" begin
             i_ray_direction = convert(I, -2)
             j_ray_direction = convert(I, 1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 9)
             Test.@test j_ray_stop == convert(I, 27)
             Test.@test i_ray_hit_tile == convert(I, 1)
@@ -112,7 +112,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = 0" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, 0)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 9)
             Test.@test j_ray_stop == convert(I, 21)
             Test.@test i_ray_hit_tile == convert(I, 1)
@@ -123,7 +123,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -2, delta_j = -1" begin
             i_ray_direction = convert(I, -2)
             j_ray_direction = convert(I, -1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 9)
             Test.@test j_ray_stop == convert(I, 15)
             Test.@test i_ray_hit_tile == convert(I, 1)
@@ -134,7 +134,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = -1" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, -1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 9)
             Test.@test j_ray_stop == convert(I, 9)
             Test.@test i_ray_hit_tile == convert(I, 1)
@@ -145,7 +145,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = -2" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, -2)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 15)
             Test.@test j_ray_stop == convert(I, 9)
             Test.@test i_ray_hit_tile == convert(I, 2)
@@ -156,7 +156,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 0, delta_j = -1" begin
             i_ray_direction = convert(I, 0)
             j_ray_direction = convert(I, -1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 21)
             Test.@test j_ray_stop == convert(I, 9)
             Test.@test i_ray_hit_tile == convert(I, 3)
@@ -167,7 +167,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = -2" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, -2)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 27)
             Test.@test j_ray_stop == convert(I, 9)
             Test.@test i_ray_hit_tile == convert(I, 4)
@@ -178,7 +178,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = -1" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, -1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 33)
             Test.@test j_ray_stop == convert(I, 9)
             Test.@test i_ray_hit_tile == convert(I, 5)
@@ -189,7 +189,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 2, delta_j = -1" begin
             i_ray_direction = convert(I, 2)
             j_ray_direction = convert(I, -1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 33)
             Test.@test j_ray_stop == convert(I, 15)
             Test.@test i_ray_hit_tile == convert(I, 5)
@@ -198,16 +198,16 @@ Test.@testset "RayCaster.jl" begin
         end
     end
 
-    Test.@testset "height_tile = 9" begin
-        height_tile = convert(I, 9)
+    Test.@testset "tile_length = 9" begin
+        tile_length = convert(I, 9)
 
-        i_ray_start = convert(I, (height_obstacle_tile_map * height_tile) ÷ 2 + 1)
-        j_ray_start = convert(I, (width_obstacle_tile_map * height_tile) ÷ 2 + 1)
+        i_ray_start = convert(I, (height_obstacle_tile_map * tile_length) ÷ 2 + 1)
+        j_ray_start = convert(I, (width_obstacle_tile_map * tile_length) ÷ 2 + 1)
 
         Test.@testset "delta_i = 1, delta_j = 0" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 0)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 37)
             Test.@test j_ray_stop == convert(I, 23)
             Test.@test i_ray_hit_tile == convert(I, 5)
@@ -218,7 +218,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 2, delta_j = 1" begin
             i_ray_direction = convert(I, 2)
             j_ray_direction = convert(I, 1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 37)
             Test.@test j_ray_stop == convert(I, 30)
             Test.@test i_ray_hit_tile == convert(I, 5)
@@ -229,7 +229,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = 1" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 37)
             Test.@test j_ray_stop == convert(I, 36)
             Test.@test i_ray_hit_tile == convert(I, 5)
@@ -240,7 +240,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = 2" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 2)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 30)
             Test.@test j_ray_stop == convert(I, 37)
             Test.@test i_ray_hit_tile == convert(I, 4)
@@ -251,7 +251,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 0, delta_j = 1" begin
             i_ray_direction = convert(I, 0)
             j_ray_direction = convert(I, 1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 23)
             Test.@test j_ray_stop == convert(I, 37)
             Test.@test i_ray_hit_tile == convert(I, 3)
@@ -262,7 +262,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = 2" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, 2)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 16)
             Test.@test j_ray_stop == convert(I, 37)
             Test.@test i_ray_hit_tile == convert(I, 2)
@@ -273,7 +273,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = 1" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, 1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 10)
             Test.@test j_ray_stop == convert(I, 36)
             Test.@test i_ray_hit_tile == convert(I, 1)
@@ -284,7 +284,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -2, delta_j = 1" begin
             i_ray_direction = convert(I, -2)
             j_ray_direction = convert(I, 1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 10)
             Test.@test j_ray_stop == convert(I, 29)
             Test.@test i_ray_hit_tile == convert(I, 1)
@@ -295,7 +295,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = 0" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, 0)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 10)
             Test.@test j_ray_stop == convert(I, 23)
             Test.@test i_ray_hit_tile == convert(I, 1)
@@ -306,7 +306,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -2, delta_j = -1" begin
             i_ray_direction = convert(I, -2)
             j_ray_direction = convert(I, -1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 10)
             Test.@test j_ray_stop == convert(I, 17)
             Test.@test i_ray_hit_tile == convert(I, 1)
@@ -317,7 +317,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = -1" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, -1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 10)
             Test.@test j_ray_stop == convert(I, 10)
             Test.@test i_ray_hit_tile == convert(I, 1)
@@ -328,7 +328,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = -2" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, -2)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 17)
             Test.@test j_ray_stop == convert(I, 10)
             Test.@test i_ray_hit_tile == convert(I, 2)
@@ -339,7 +339,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 0, delta_j = -1" begin
             i_ray_direction = convert(I, 0)
             j_ray_direction = convert(I, -1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 23)
             Test.@test j_ray_stop == convert(I, 10)
             Test.@test i_ray_hit_tile == convert(I, 3)
@@ -350,7 +350,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = -2" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, -2)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 29)
             Test.@test j_ray_stop == convert(I, 10)
             Test.@test i_ray_hit_tile == convert(I, 4)
@@ -361,7 +361,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = -1" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, -1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 36)
             Test.@test j_ray_stop == convert(I, 10)
             Test.@test i_ray_hit_tile == convert(I, 4)
@@ -372,7 +372,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 2, delta_j = -1" begin
             i_ray_direction = convert(I, 2)
             j_ray_direction = convert(I, -1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 37)
             Test.@test j_ray_stop == convert(I, 16)
             Test.@test i_ray_hit_tile == convert(I, 5)
@@ -381,16 +381,16 @@ Test.@testset "RayCaster.jl" begin
         end
     end
 
-    Test.@testset "height_tile = 1" begin
-        height_tile = convert(I, 1)
+    Test.@testset "tile_length = 1" begin
+        tile_length = convert(I, 1)
 
-        i_ray_start = convert(I, (height_obstacle_tile_map * height_tile) ÷ 2 + 1)
-        j_ray_start = convert(I, (width_obstacle_tile_map * height_tile) ÷ 2 + 1)
+        i_ray_start = convert(I, (height_obstacle_tile_map * tile_length) ÷ 2 + 1)
+        j_ray_start = convert(I, (width_obstacle_tile_map * tile_length) ÷ 2 + 1)
 
         Test.@testset "delta_i = 1, delta_j = 0" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 0)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 5)
             Test.@test j_ray_stop == convert(I, 3)
             Test.@test i_ray_hit_tile == convert(I, 5)
@@ -401,7 +401,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 2, delta_j = 1" begin
             i_ray_direction = convert(I, 2)
             j_ray_direction = convert(I, 1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 5)
             Test.@test j_ray_stop == convert(I, 3)
             Test.@test i_ray_hit_tile == convert(I, 5)
@@ -412,7 +412,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = 1" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 5)
             Test.@test j_ray_stop == convert(I, 4)
             Test.@test i_ray_hit_tile == convert(I, 5)
@@ -423,7 +423,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = 2" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 2)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 4)
             Test.@test j_ray_stop == convert(I, 5)
             Test.@test i_ray_hit_tile == convert(I, 4)
@@ -434,7 +434,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 0, delta_j = 1" begin
             i_ray_direction = convert(I, 0)
             j_ray_direction = convert(I, 1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 3)
             Test.@test j_ray_stop == convert(I, 5)
             Test.@test i_ray_hit_tile == convert(I, 3)
@@ -445,7 +445,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = 2" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, 2)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 2)
             Test.@test j_ray_stop == convert(I, 4)
             Test.@test i_ray_hit_tile == convert(I, 1)
@@ -456,7 +456,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = 1" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, 1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 2)
             Test.@test j_ray_stop == convert(I, 3)
             Test.@test i_ray_hit_tile == convert(I, 1)
@@ -467,7 +467,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -2, delta_j = 1" begin
             i_ray_direction = convert(I, -2)
             j_ray_direction = convert(I, 1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 2)
             Test.@test j_ray_stop == convert(I, 3)
             Test.@test i_ray_hit_tile == convert(I, 1)
@@ -478,7 +478,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = 0" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, 0)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 2)
             Test.@test j_ray_stop == convert(I, 3)
             Test.@test i_ray_hit_tile == convert(I, 1)
@@ -489,7 +489,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -2, delta_j = -1" begin
             i_ray_direction = convert(I, -2)
             j_ray_direction = convert(I, -1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 2)
             Test.@test j_ray_stop == convert(I, 2)
             Test.@test i_ray_hit_tile == convert(I, 1)
@@ -500,7 +500,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = -1" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, -1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 2)
             Test.@test j_ray_stop == convert(I, 2)
             Test.@test i_ray_hit_tile == convert(I, 1)
@@ -511,7 +511,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = -2" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, -2)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 2)
             Test.@test j_ray_stop == convert(I, 2)
             Test.@test i_ray_hit_tile == convert(I, 2)
@@ -522,7 +522,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 0, delta_j = -1" begin
             i_ray_direction = convert(I, 0)
             j_ray_direction = convert(I, -1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 3)
             Test.@test j_ray_stop == convert(I, 2)
             Test.@test i_ray_hit_tile == convert(I, 3)
@@ -533,7 +533,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = -2" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, -2)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 3)
             Test.@test j_ray_stop == convert(I, 2)
             Test.@test i_ray_hit_tile == convert(I, 3)
@@ -544,7 +544,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = -1" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, -1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 4)
             Test.@test j_ray_stop == convert(I, 2)
             Test.@test i_ray_hit_tile == convert(I, 4)
@@ -555,7 +555,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 2, delta_j = -1" begin
             i_ray_direction = convert(I, 2)
             j_ray_direction = convert(I, -1)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 5)
             Test.@test j_ray_stop == convert(I, 2)
             Test.@test i_ray_hit_tile == convert(I, 5)
@@ -565,7 +565,7 @@ Test.@testset "RayCaster.jl" begin
     end
 
     Test.@testset "starting inside an obstacle tile" begin
-        height_tile = convert(I, 8)
+        tile_length = convert(I, 8)
 
         i_ray_start = convert(I, 3)
         j_ray_start = convert(I, 4)
@@ -573,7 +573,7 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = 0" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 0)
-            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, height_tile, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, tile_length, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop == convert(I, 3)
             Test.@test j_ray_stop == convert(I, 4)
             Test.@test i_ray_hit_tile == convert(I, 1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,8 +18,8 @@ Test.@testset "RayCaster.jl" begin
     Test.@testset "height_tile = 8" begin
         height_tile = convert(I, 8)
 
-        i_ray_start = convert(I, height_obstacle_tile_map * height_tile ÷ 2 + 1)
-        j_ray_start = convert(I, width_obstacle_tile_map * height_tile ÷ 2 + 1)
+        i_ray_start = convert(I, (height_obstacle_tile_map * height_tile) ÷ 2 + 1)
+        j_ray_start = convert(I, (width_obstacle_tile_map * height_tile) ÷ 2 + 1)
 
         Test.@testset "delta_i = 1, delta_j = 0" begin
             i_ray_direction = convert(I, 1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,7 +25,7 @@ Test.@testset "RayCaster.jl" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 0)
             i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 32)
+            Test.@test i_ray_stop_cell == convert(I, 33)
             Test.@test j_ray_stop_cell == convert(I, 21)
             Test.@test i_ray_hit_tile == convert(I, 5)
             Test.@test j_ray_hit_tile == convert(I, 3)
@@ -36,8 +36,8 @@ Test.@testset "RayCaster.jl" begin
             i_ray_direction = convert(I, 2)
             j_ray_direction = convert(I, 1)
             i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 32)
-            Test.@test j_ray_stop_cell == convert(I, 28)
+            Test.@test i_ray_stop_cell == convert(I, 33)
+            Test.@test j_ray_stop_cell == convert(I, 27)
             Test.@test i_ray_hit_tile == convert(I, 5)
             Test.@test j_ray_hit_tile == convert(I, 4)
             Test.@test hit_dimension == 1
@@ -47,7 +47,7 @@ Test.@testset "RayCaster.jl" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 1)
             i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 32)
+            Test.@test i_ray_stop_cell == convert(I, 33)
             Test.@test j_ray_stop_cell == convert(I, 32)
             Test.@test i_ray_hit_tile == convert(I, 5)
             Test.@test j_ray_hit_tile == convert(I, 4)
@@ -58,8 +58,8 @@ Test.@testset "RayCaster.jl" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 2)
             i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 28)
-            Test.@test j_ray_stop_cell == convert(I, 32)
+            Test.@test i_ray_stop_cell == convert(I, 27)
+            Test.@test j_ray_stop_cell == convert(I, 33)
             Test.@test i_ray_hit_tile == convert(I, 4)
             Test.@test j_ray_hit_tile == convert(I, 5)
             Test.@test hit_dimension == 2
@@ -70,7 +70,7 @@ Test.@testset "RayCaster.jl" begin
             j_ray_direction = convert(I, 1)
             i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop_cell == convert(I, 21)
-            Test.@test j_ray_stop_cell == convert(I, 32)
+            Test.@test j_ray_stop_cell == convert(I, 33)
             Test.@test i_ray_hit_tile == convert(I, 3)
             Test.@test j_ray_hit_tile == convert(I, 5)
             Test.@test hit_dimension == 2
@@ -80,8 +80,8 @@ Test.@testset "RayCaster.jl" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, 2)
             i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 14)
-            Test.@test j_ray_stop_cell == convert(I, 32)
+            Test.@test i_ray_stop_cell == convert(I, 15)
+            Test.@test j_ray_stop_cell == convert(I, 33)
             Test.@test i_ray_hit_tile == convert(I, 2)
             Test.@test j_ray_hit_tile == convert(I, 5)
             Test.@test hit_dimension == 2
@@ -91,11 +91,11 @@ Test.@testset "RayCaster.jl" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, 1)
             i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 10)
+            Test.@test i_ray_stop_cell == convert(I, 9)
             Test.@test j_ray_stop_cell == convert(I, 32)
-            Test.@test i_ray_hit_tile == convert(I, 2)
-            Test.@test j_ray_hit_tile == convert(I, 5)
-            Test.@test hit_dimension == 2
+            Test.@test i_ray_hit_tile == convert(I, 1)
+            Test.@test j_ray_hit_tile == convert(I, 4)
+            Test.@test hit_dimension == 1
         end
 
         Test.@testset "delta_i = -2, delta_j = 1" begin
@@ -103,7 +103,7 @@ Test.@testset "RayCaster.jl" begin
             j_ray_direction = convert(I, 1)
             i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop_cell == convert(I, 9)
-            Test.@test j_ray_stop_cell == convert(I, 29)
+            Test.@test j_ray_stop_cell == convert(I, 27)
             Test.@test i_ray_hit_tile == convert(I, 1)
             Test.@test j_ray_hit_tile == convert(I, 4)
             Test.@test hit_dimension == 1
@@ -125,7 +125,7 @@ Test.@testset "RayCaster.jl" begin
             j_ray_direction = convert(I, -1)
             i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop_cell == convert(I, 9)
-            Test.@test j_ray_stop_cell == convert(I, 13)
+            Test.@test j_ray_stop_cell == convert(I, 15)
             Test.@test i_ray_hit_tile == convert(I, 1)
             Test.@test j_ray_hit_tile == convert(I, 2)
             Test.@test hit_dimension == 1
@@ -146,7 +146,7 @@ Test.@testset "RayCaster.jl" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, -2)
             i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 13)
+            Test.@test i_ray_stop_cell == convert(I, 15)
             Test.@test j_ray_stop_cell == convert(I, 9)
             Test.@test i_ray_hit_tile == convert(I, 2)
             Test.@test j_ray_hit_tile == convert(I, 1)
@@ -168,7 +168,7 @@ Test.@testset "RayCaster.jl" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, -2)
             i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 29)
+            Test.@test i_ray_stop_cell == convert(I, 27)
             Test.@test j_ray_stop_cell == convert(I, 9)
             Test.@test i_ray_hit_tile == convert(I, 4)
             Test.@test j_ray_hit_tile == convert(I, 1)
@@ -179,8 +179,8 @@ Test.@testset "RayCaster.jl" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, -1)
             i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 32)
-            Test.@test j_ray_stop_cell == convert(I, 10)
+            Test.@test i_ray_stop_cell == convert(I, 33)
+            Test.@test j_ray_stop_cell == convert(I, 9)
             Test.@test i_ray_hit_tile == convert(I, 5)
             Test.@test j_ray_hit_tile == convert(I, 2)
             Test.@test hit_dimension == 1
@@ -190,8 +190,8 @@ Test.@testset "RayCaster.jl" begin
             i_ray_direction = convert(I, 2)
             j_ray_direction = convert(I, -1)
             i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 32)
-            Test.@test j_ray_stop_cell == convert(I, 14)
+            Test.@test i_ray_stop_cell == convert(I, 33)
+            Test.@test j_ray_stop_cell == convert(I, 15)
             Test.@test i_ray_hit_tile == convert(I, 5)
             Test.@test j_ray_hit_tile == convert(I, 2)
             Test.@test hit_dimension == 1
@@ -208,7 +208,7 @@ Test.@testset "RayCaster.jl" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 0)
             i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 36)
+            Test.@test i_ray_stop_cell == convert(I, 37)
             Test.@test j_ray_stop_cell == convert(I, 23)
             Test.@test i_ray_hit_tile == convert(I, 5)
             Test.@test j_ray_hit_tile == convert(I, 3)
@@ -219,8 +219,8 @@ Test.@testset "RayCaster.jl" begin
             i_ray_direction = convert(I, 2)
             j_ray_direction = convert(I, 1)
             i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 36)
-            Test.@test j_ray_stop_cell == convert(I, 31)
+            Test.@test i_ray_stop_cell == convert(I, 37)
+            Test.@test j_ray_stop_cell == convert(I, 30)
             Test.@test i_ray_hit_tile == convert(I, 5)
             Test.@test j_ray_hit_tile == convert(I, 4)
             Test.@test hit_dimension == 1
@@ -230,7 +230,7 @@ Test.@testset "RayCaster.jl" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 1)
             i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 36)
+            Test.@test i_ray_stop_cell == convert(I, 37)
             Test.@test j_ray_stop_cell == convert(I, 36)
             Test.@test i_ray_hit_tile == convert(I, 5)
             Test.@test j_ray_hit_tile == convert(I, 4)
@@ -241,8 +241,8 @@ Test.@testset "RayCaster.jl" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 2)
             i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 31)
-            Test.@test j_ray_stop_cell == convert(I, 36)
+            Test.@test i_ray_stop_cell == convert(I, 30)
+            Test.@test j_ray_stop_cell == convert(I, 37)
             Test.@test i_ray_hit_tile == convert(I, 4)
             Test.@test j_ray_hit_tile == convert(I, 5)
             Test.@test hit_dimension == 2
@@ -253,7 +253,7 @@ Test.@testset "RayCaster.jl" begin
             j_ray_direction = convert(I, 1)
             i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop_cell == convert(I, 23)
-            Test.@test j_ray_stop_cell == convert(I, 36)
+            Test.@test j_ray_stop_cell == convert(I, 37)
             Test.@test i_ray_hit_tile == convert(I, 3)
             Test.@test j_ray_hit_tile == convert(I, 5)
             Test.@test hit_dimension == 2
@@ -263,8 +263,8 @@ Test.@testset "RayCaster.jl" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, 2)
             i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 15)
-            Test.@test j_ray_stop_cell == convert(I, 36)
+            Test.@test i_ray_stop_cell == convert(I, 16)
+            Test.@test j_ray_stop_cell == convert(I, 37)
             Test.@test i_ray_hit_tile == convert(I, 2)
             Test.@test j_ray_hit_tile == convert(I, 5)
             Test.@test hit_dimension == 2
@@ -286,7 +286,7 @@ Test.@testset "RayCaster.jl" begin
             j_ray_direction = convert(I, 1)
             i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop_cell == convert(I, 10)
-            Test.@test j_ray_stop_cell == convert(I, 31)
+            Test.@test j_ray_stop_cell == convert(I, 29)
             Test.@test i_ray_hit_tile == convert(I, 1)
             Test.@test j_ray_hit_tile == convert(I, 4)
             Test.@test hit_dimension == 1
@@ -308,7 +308,7 @@ Test.@testset "RayCaster.jl" begin
             j_ray_direction = convert(I, -1)
             i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop_cell == convert(I, 10)
-            Test.@test j_ray_stop_cell == convert(I, 15)
+            Test.@test j_ray_stop_cell == convert(I, 17)
             Test.@test i_ray_hit_tile == convert(I, 1)
             Test.@test j_ray_hit_tile == convert(I, 2)
             Test.@test hit_dimension == 1
@@ -329,7 +329,7 @@ Test.@testset "RayCaster.jl" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, -2)
             i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 15)
+            Test.@test i_ray_stop_cell == convert(I, 17)
             Test.@test j_ray_stop_cell == convert(I, 10)
             Test.@test i_ray_hit_tile == convert(I, 2)
             Test.@test j_ray_hit_tile == convert(I, 1)
@@ -351,7 +351,7 @@ Test.@testset "RayCaster.jl" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, -2)
             i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 31)
+            Test.@test i_ray_stop_cell == convert(I, 29)
             Test.@test j_ray_stop_cell == convert(I, 10)
             Test.@test i_ray_hit_tile == convert(I, 4)
             Test.@test j_ray_hit_tile == convert(I, 1)
@@ -364,17 +364,17 @@ Test.@testset "RayCaster.jl" begin
             i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop_cell == convert(I, 36)
             Test.@test j_ray_stop_cell == convert(I, 10)
-            Test.@test i_ray_hit_tile == convert(I, 5)
-            Test.@test j_ray_hit_tile == convert(I, 2)
-            Test.@test hit_dimension == 1
+            Test.@test i_ray_hit_tile == convert(I, 4)
+            Test.@test j_ray_hit_tile == convert(I, 1)
+            Test.@test hit_dimension == 2
         end
 
         Test.@testset "delta_i = 2, delta_j = -1" begin
             i_ray_direction = convert(I, 2)
             j_ray_direction = convert(I, -1)
             i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 36)
-            Test.@test j_ray_stop_cell == convert(I, 15)
+            Test.@test i_ray_stop_cell == convert(I, 37)
+            Test.@test j_ray_stop_cell == convert(I, 16)
             Test.@test i_ray_hit_tile == convert(I, 5)
             Test.@test j_ray_hit_tile == convert(I, 2)
             Test.@test hit_dimension == 1
@@ -391,7 +391,7 @@ Test.@testset "RayCaster.jl" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 0)
             i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 4)
+            Test.@test i_ray_stop_cell == convert(I, 5)
             Test.@test j_ray_stop_cell == convert(I, 3)
             Test.@test i_ray_hit_tile == convert(I, 5)
             Test.@test j_ray_hit_tile == convert(I, 3)
@@ -402,10 +402,10 @@ Test.@testset "RayCaster.jl" begin
             i_ray_direction = convert(I, 2)
             j_ray_direction = convert(I, 1)
             i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 4)
-            Test.@test j_ray_stop_cell == convert(I, 4)
+            Test.@test i_ray_stop_cell == convert(I, 5)
+            Test.@test j_ray_stop_cell == convert(I, 3)
             Test.@test i_ray_hit_tile == convert(I, 5)
-            Test.@test j_ray_hit_tile == convert(I, 4)
+            Test.@test j_ray_hit_tile == convert(I, 3)
             Test.@test hit_dimension == 1
         end
 
@@ -413,7 +413,7 @@ Test.@testset "RayCaster.jl" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 1)
             i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 4)
+            Test.@test i_ray_stop_cell == convert(I, 5)
             Test.@test j_ray_stop_cell == convert(I, 4)
             Test.@test i_ray_hit_tile == convert(I, 5)
             Test.@test j_ray_hit_tile == convert(I, 4)
@@ -425,7 +425,7 @@ Test.@testset "RayCaster.jl" begin
             j_ray_direction = convert(I, 2)
             i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop_cell == convert(I, 4)
-            Test.@test j_ray_stop_cell == convert(I, 4)
+            Test.@test j_ray_stop_cell == convert(I, 5)
             Test.@test i_ray_hit_tile == convert(I, 4)
             Test.@test j_ray_hit_tile == convert(I, 5)
             Test.@test hit_dimension == 2
@@ -436,7 +436,7 @@ Test.@testset "RayCaster.jl" begin
             j_ray_direction = convert(I, 1)
             i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop_cell == convert(I, 3)
-            Test.@test j_ray_stop_cell == convert(I, 4)
+            Test.@test j_ray_stop_cell == convert(I, 5)
             Test.@test i_ray_hit_tile == convert(I, 3)
             Test.@test j_ray_hit_tile == convert(I, 5)
             Test.@test hit_dimension == 2
@@ -448,9 +448,9 @@ Test.@testset "RayCaster.jl" begin
             i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop_cell == convert(I, 2)
             Test.@test j_ray_stop_cell == convert(I, 4)
-            Test.@test i_ray_hit_tile == convert(I, 2)
-            Test.@test j_ray_hit_tile == convert(I, 5)
-            Test.@test hit_dimension == 2
+            Test.@test i_ray_hit_tile == convert(I, 1)
+            Test.@test j_ray_hit_tile == convert(I, 4)
+            Test.@test hit_dimension == 1
         end
 
         Test.@testset "delta_i = -1, delta_j = 1" begin
@@ -458,9 +458,9 @@ Test.@testset "RayCaster.jl" begin
             j_ray_direction = convert(I, 1)
             i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop_cell == convert(I, 2)
-            Test.@test j_ray_stop_cell == convert(I, 4)
+            Test.@test j_ray_stop_cell == convert(I, 3)
             Test.@test i_ray_hit_tile == convert(I, 1)
-            Test.@test j_ray_hit_tile == convert(I, 4)
+            Test.@test j_ray_hit_tile == convert(I, 3)
             Test.@test hit_dimension == 1
         end
 
@@ -469,9 +469,9 @@ Test.@testset "RayCaster.jl" begin
             j_ray_direction = convert(I, 1)
             i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop_cell == convert(I, 2)
-            Test.@test j_ray_stop_cell == convert(I, 4)
+            Test.@test j_ray_stop_cell == convert(I, 3)
             Test.@test i_ray_hit_tile == convert(I, 1)
-            Test.@test j_ray_hit_tile == convert(I, 4)
+            Test.@test j_ray_hit_tile == convert(I, 3)
             Test.@test hit_dimension == 1
         end
 
@@ -534,9 +534,9 @@ Test.@testset "RayCaster.jl" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, -2)
             i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 4)
+            Test.@test i_ray_stop_cell == convert(I, 3)
             Test.@test j_ray_stop_cell == convert(I, 2)
-            Test.@test i_ray_hit_tile == convert(I, 4)
+            Test.@test i_ray_hit_tile == convert(I, 3)
             Test.@test j_ray_hit_tile == convert(I, 1)
             Test.@test hit_dimension == 2
         end
@@ -547,16 +547,16 @@ Test.@testset "RayCaster.jl" begin
             i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
             Test.@test i_ray_stop_cell == convert(I, 4)
             Test.@test j_ray_stop_cell == convert(I, 2)
-            Test.@test i_ray_hit_tile == convert(I, 5)
-            Test.@test j_ray_hit_tile == convert(I, 2)
-            Test.@test hit_dimension == 1
+            Test.@test i_ray_hit_tile == convert(I, 4)
+            Test.@test j_ray_hit_tile == convert(I, 1)
+            Test.@test hit_dimension == 2
         end
 
         Test.@testset "delta_i = 2, delta_j = -1" begin
             i_ray_direction = convert(I, 2)
             j_ray_direction = convert(I, -1)
             i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 4)
+            Test.@test i_ray_stop_cell == convert(I, 5)
             Test.@test j_ray_stop_cell == convert(I, 2)
             Test.@test i_ray_hit_tile == convert(I, 5)
             Test.@test j_ray_hit_tile == convert(I, 2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,15 +18,15 @@ Test.@testset "RayCaster.jl" begin
     Test.@testset "cells_per_tile_1d = 8" begin
         cells_per_tile_1d = convert(I, 8)
 
-        i_ray_start_cell = convert(I, height_obstacle_tile_map * cells_per_tile_1d ÷ 2 + 1)
-        j_ray_start_cell = convert(I, width_obstacle_tile_map * cells_per_tile_1d ÷ 2 + 1)
+        i_ray_start = convert(I, height_obstacle_tile_map * cells_per_tile_1d ÷ 2 + 1)
+        j_ray_start = convert(I, width_obstacle_tile_map * cells_per_tile_1d ÷ 2 + 1)
 
         Test.@testset "delta_i = 1, delta_j = 0" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 0)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 33)
-            Test.@test j_ray_stop_cell == convert(I, 21)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 33)
+            Test.@test j_ray_stop == convert(I, 21)
             Test.@test i_ray_hit_tile == convert(I, 5)
             Test.@test j_ray_hit_tile == convert(I, 3)
             Test.@test hit_dimension == 1
@@ -35,9 +35,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 2, delta_j = 1" begin
             i_ray_direction = convert(I, 2)
             j_ray_direction = convert(I, 1)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 33)
-            Test.@test j_ray_stop_cell == convert(I, 27)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 33)
+            Test.@test j_ray_stop == convert(I, 27)
             Test.@test i_ray_hit_tile == convert(I, 5)
             Test.@test j_ray_hit_tile == convert(I, 4)
             Test.@test hit_dimension == 1
@@ -46,9 +46,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = 1" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 1)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 33)
-            Test.@test j_ray_stop_cell == convert(I, 32)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 33)
+            Test.@test j_ray_stop == convert(I, 32)
             Test.@test i_ray_hit_tile == convert(I, 5)
             Test.@test j_ray_hit_tile == convert(I, 4)
             Test.@test hit_dimension == 1
@@ -57,9 +57,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = 2" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 2)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 27)
-            Test.@test j_ray_stop_cell == convert(I, 33)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 27)
+            Test.@test j_ray_stop == convert(I, 33)
             Test.@test i_ray_hit_tile == convert(I, 4)
             Test.@test j_ray_hit_tile == convert(I, 5)
             Test.@test hit_dimension == 2
@@ -68,9 +68,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 0, delta_j = 1" begin
             i_ray_direction = convert(I, 0)
             j_ray_direction = convert(I, 1)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 21)
-            Test.@test j_ray_stop_cell == convert(I, 33)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 21)
+            Test.@test j_ray_stop == convert(I, 33)
             Test.@test i_ray_hit_tile == convert(I, 3)
             Test.@test j_ray_hit_tile == convert(I, 5)
             Test.@test hit_dimension == 2
@@ -79,9 +79,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = 2" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, 2)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 15)
-            Test.@test j_ray_stop_cell == convert(I, 33)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 15)
+            Test.@test j_ray_stop == convert(I, 33)
             Test.@test i_ray_hit_tile == convert(I, 2)
             Test.@test j_ray_hit_tile == convert(I, 5)
             Test.@test hit_dimension == 2
@@ -90,9 +90,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = 1" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, 1)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 9)
-            Test.@test j_ray_stop_cell == convert(I, 32)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 9)
+            Test.@test j_ray_stop == convert(I, 32)
             Test.@test i_ray_hit_tile == convert(I, 1)
             Test.@test j_ray_hit_tile == convert(I, 4)
             Test.@test hit_dimension == 1
@@ -101,9 +101,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -2, delta_j = 1" begin
             i_ray_direction = convert(I, -2)
             j_ray_direction = convert(I, 1)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 9)
-            Test.@test j_ray_stop_cell == convert(I, 27)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 9)
+            Test.@test j_ray_stop == convert(I, 27)
             Test.@test i_ray_hit_tile == convert(I, 1)
             Test.@test j_ray_hit_tile == convert(I, 4)
             Test.@test hit_dimension == 1
@@ -112,9 +112,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = 0" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, 0)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 9)
-            Test.@test j_ray_stop_cell == convert(I, 21)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 9)
+            Test.@test j_ray_stop == convert(I, 21)
             Test.@test i_ray_hit_tile == convert(I, 1)
             Test.@test j_ray_hit_tile == convert(I, 3)
             Test.@test hit_dimension == 1
@@ -123,9 +123,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -2, delta_j = -1" begin
             i_ray_direction = convert(I, -2)
             j_ray_direction = convert(I, -1)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 9)
-            Test.@test j_ray_stop_cell == convert(I, 15)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 9)
+            Test.@test j_ray_stop == convert(I, 15)
             Test.@test i_ray_hit_tile == convert(I, 1)
             Test.@test j_ray_hit_tile == convert(I, 2)
             Test.@test hit_dimension == 1
@@ -134,9 +134,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = -1" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, -1)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 9)
-            Test.@test j_ray_stop_cell == convert(I, 9)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 9)
+            Test.@test j_ray_stop == convert(I, 9)
             Test.@test i_ray_hit_tile == convert(I, 1)
             Test.@test j_ray_hit_tile == convert(I, 2)
             Test.@test hit_dimension == 1
@@ -145,9 +145,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = -2" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, -2)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 15)
-            Test.@test j_ray_stop_cell == convert(I, 9)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 15)
+            Test.@test j_ray_stop == convert(I, 9)
             Test.@test i_ray_hit_tile == convert(I, 2)
             Test.@test j_ray_hit_tile == convert(I, 1)
             Test.@test hit_dimension == 2
@@ -156,9 +156,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 0, delta_j = -1" begin
             i_ray_direction = convert(I, 0)
             j_ray_direction = convert(I, -1)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 21)
-            Test.@test j_ray_stop_cell == convert(I, 9)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 21)
+            Test.@test j_ray_stop == convert(I, 9)
             Test.@test i_ray_hit_tile == convert(I, 3)
             Test.@test j_ray_hit_tile == convert(I, 1)
             Test.@test hit_dimension == 2
@@ -167,9 +167,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = -2" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, -2)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 27)
-            Test.@test j_ray_stop_cell == convert(I, 9)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 27)
+            Test.@test j_ray_stop == convert(I, 9)
             Test.@test i_ray_hit_tile == convert(I, 4)
             Test.@test j_ray_hit_tile == convert(I, 1)
             Test.@test hit_dimension == 2
@@ -178,9 +178,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = -1" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, -1)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 33)
-            Test.@test j_ray_stop_cell == convert(I, 9)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 33)
+            Test.@test j_ray_stop == convert(I, 9)
             Test.@test i_ray_hit_tile == convert(I, 5)
             Test.@test j_ray_hit_tile == convert(I, 2)
             Test.@test hit_dimension == 1
@@ -189,9 +189,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 2, delta_j = -1" begin
             i_ray_direction = convert(I, 2)
             j_ray_direction = convert(I, -1)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 33)
-            Test.@test j_ray_stop_cell == convert(I, 15)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 33)
+            Test.@test j_ray_stop == convert(I, 15)
             Test.@test i_ray_hit_tile == convert(I, 5)
             Test.@test j_ray_hit_tile == convert(I, 2)
             Test.@test hit_dimension == 1
@@ -201,15 +201,15 @@ Test.@testset "RayCaster.jl" begin
     Test.@testset "cells_per_tile_1d = 9" begin
         cells_per_tile_1d = convert(I, 9)
 
-        i_ray_start_cell = convert(I, (height_obstacle_tile_map * cells_per_tile_1d) ÷ 2 + 1)
-        j_ray_start_cell = convert(I, (width_obstacle_tile_map * cells_per_tile_1d) ÷ 2 + 1)
+        i_ray_start = convert(I, (height_obstacle_tile_map * cells_per_tile_1d) ÷ 2 + 1)
+        j_ray_start = convert(I, (width_obstacle_tile_map * cells_per_tile_1d) ÷ 2 + 1)
 
         Test.@testset "delta_i = 1, delta_j = 0" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 0)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 37)
-            Test.@test j_ray_stop_cell == convert(I, 23)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 37)
+            Test.@test j_ray_stop == convert(I, 23)
             Test.@test i_ray_hit_tile == convert(I, 5)
             Test.@test j_ray_hit_tile == convert(I, 3)
             Test.@test hit_dimension == 1
@@ -218,9 +218,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 2, delta_j = 1" begin
             i_ray_direction = convert(I, 2)
             j_ray_direction = convert(I, 1)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 37)
-            Test.@test j_ray_stop_cell == convert(I, 30)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 37)
+            Test.@test j_ray_stop == convert(I, 30)
             Test.@test i_ray_hit_tile == convert(I, 5)
             Test.@test j_ray_hit_tile == convert(I, 4)
             Test.@test hit_dimension == 1
@@ -229,9 +229,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = 1" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 1)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 37)
-            Test.@test j_ray_stop_cell == convert(I, 36)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 37)
+            Test.@test j_ray_stop == convert(I, 36)
             Test.@test i_ray_hit_tile == convert(I, 5)
             Test.@test j_ray_hit_tile == convert(I, 4)
             Test.@test hit_dimension == 1
@@ -240,9 +240,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = 2" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 2)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 30)
-            Test.@test j_ray_stop_cell == convert(I, 37)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 30)
+            Test.@test j_ray_stop == convert(I, 37)
             Test.@test i_ray_hit_tile == convert(I, 4)
             Test.@test j_ray_hit_tile == convert(I, 5)
             Test.@test hit_dimension == 2
@@ -251,9 +251,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 0, delta_j = 1" begin
             i_ray_direction = convert(I, 0)
             j_ray_direction = convert(I, 1)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 23)
-            Test.@test j_ray_stop_cell == convert(I, 37)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 23)
+            Test.@test j_ray_stop == convert(I, 37)
             Test.@test i_ray_hit_tile == convert(I, 3)
             Test.@test j_ray_hit_tile == convert(I, 5)
             Test.@test hit_dimension == 2
@@ -262,9 +262,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = 2" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, 2)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 16)
-            Test.@test j_ray_stop_cell == convert(I, 37)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 16)
+            Test.@test j_ray_stop == convert(I, 37)
             Test.@test i_ray_hit_tile == convert(I, 2)
             Test.@test j_ray_hit_tile == convert(I, 5)
             Test.@test hit_dimension == 2
@@ -273,9 +273,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = 1" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, 1)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 10)
-            Test.@test j_ray_stop_cell == convert(I, 36)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 10)
+            Test.@test j_ray_stop == convert(I, 36)
             Test.@test i_ray_hit_tile == convert(I, 1)
             Test.@test j_ray_hit_tile == convert(I, 4)
             Test.@test hit_dimension == 1
@@ -284,9 +284,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -2, delta_j = 1" begin
             i_ray_direction = convert(I, -2)
             j_ray_direction = convert(I, 1)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 10)
-            Test.@test j_ray_stop_cell == convert(I, 29)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 10)
+            Test.@test j_ray_stop == convert(I, 29)
             Test.@test i_ray_hit_tile == convert(I, 1)
             Test.@test j_ray_hit_tile == convert(I, 4)
             Test.@test hit_dimension == 1
@@ -295,9 +295,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = 0" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, 0)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 10)
-            Test.@test j_ray_stop_cell == convert(I, 23)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 10)
+            Test.@test j_ray_stop == convert(I, 23)
             Test.@test i_ray_hit_tile == convert(I, 1)
             Test.@test j_ray_hit_tile == convert(I, 3)
             Test.@test hit_dimension == 1
@@ -306,9 +306,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -2, delta_j = -1" begin
             i_ray_direction = convert(I, -2)
             j_ray_direction = convert(I, -1)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 10)
-            Test.@test j_ray_stop_cell == convert(I, 17)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 10)
+            Test.@test j_ray_stop == convert(I, 17)
             Test.@test i_ray_hit_tile == convert(I, 1)
             Test.@test j_ray_hit_tile == convert(I, 2)
             Test.@test hit_dimension == 1
@@ -317,9 +317,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = -1" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, -1)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 10)
-            Test.@test j_ray_stop_cell == convert(I, 10)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 10)
+            Test.@test j_ray_stop == convert(I, 10)
             Test.@test i_ray_hit_tile == convert(I, 1)
             Test.@test j_ray_hit_tile == convert(I, 2)
             Test.@test hit_dimension == 1
@@ -328,9 +328,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = -2" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, -2)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 17)
-            Test.@test j_ray_stop_cell == convert(I, 10)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 17)
+            Test.@test j_ray_stop == convert(I, 10)
             Test.@test i_ray_hit_tile == convert(I, 2)
             Test.@test j_ray_hit_tile == convert(I, 1)
             Test.@test hit_dimension == 2
@@ -339,9 +339,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 0, delta_j = -1" begin
             i_ray_direction = convert(I, 0)
             j_ray_direction = convert(I, -1)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 23)
-            Test.@test j_ray_stop_cell == convert(I, 10)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 23)
+            Test.@test j_ray_stop == convert(I, 10)
             Test.@test i_ray_hit_tile == convert(I, 3)
             Test.@test j_ray_hit_tile == convert(I, 1)
             Test.@test hit_dimension == 2
@@ -350,9 +350,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = -2" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, -2)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 29)
-            Test.@test j_ray_stop_cell == convert(I, 10)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 29)
+            Test.@test j_ray_stop == convert(I, 10)
             Test.@test i_ray_hit_tile == convert(I, 4)
             Test.@test j_ray_hit_tile == convert(I, 1)
             Test.@test hit_dimension == 2
@@ -361,9 +361,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = -1" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, -1)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 36)
-            Test.@test j_ray_stop_cell == convert(I, 10)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 36)
+            Test.@test j_ray_stop == convert(I, 10)
             Test.@test i_ray_hit_tile == convert(I, 4)
             Test.@test j_ray_hit_tile == convert(I, 1)
             Test.@test hit_dimension == 2
@@ -372,9 +372,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 2, delta_j = -1" begin
             i_ray_direction = convert(I, 2)
             j_ray_direction = convert(I, -1)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 37)
-            Test.@test j_ray_stop_cell == convert(I, 16)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 37)
+            Test.@test j_ray_stop == convert(I, 16)
             Test.@test i_ray_hit_tile == convert(I, 5)
             Test.@test j_ray_hit_tile == convert(I, 2)
             Test.@test hit_dimension == 1
@@ -384,15 +384,15 @@ Test.@testset "RayCaster.jl" begin
     Test.@testset "cells_per_tile_1d = 1" begin
         cells_per_tile_1d = convert(I, 1)
 
-        i_ray_start_cell = convert(I, (height_obstacle_tile_map * cells_per_tile_1d) ÷ 2 + 1)
-        j_ray_start_cell = convert(I, (width_obstacle_tile_map * cells_per_tile_1d) ÷ 2 + 1)
+        i_ray_start = convert(I, (height_obstacle_tile_map * cells_per_tile_1d) ÷ 2 + 1)
+        j_ray_start = convert(I, (width_obstacle_tile_map * cells_per_tile_1d) ÷ 2 + 1)
 
         Test.@testset "delta_i = 1, delta_j = 0" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 0)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 5)
-            Test.@test j_ray_stop_cell == convert(I, 3)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 5)
+            Test.@test j_ray_stop == convert(I, 3)
             Test.@test i_ray_hit_tile == convert(I, 5)
             Test.@test j_ray_hit_tile == convert(I, 3)
             Test.@test hit_dimension == 1
@@ -401,9 +401,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 2, delta_j = 1" begin
             i_ray_direction = convert(I, 2)
             j_ray_direction = convert(I, 1)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 5)
-            Test.@test j_ray_stop_cell == convert(I, 3)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 5)
+            Test.@test j_ray_stop == convert(I, 3)
             Test.@test i_ray_hit_tile == convert(I, 5)
             Test.@test j_ray_hit_tile == convert(I, 3)
             Test.@test hit_dimension == 1
@@ -412,9 +412,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = 1" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 1)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 5)
-            Test.@test j_ray_stop_cell == convert(I, 4)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 5)
+            Test.@test j_ray_stop == convert(I, 4)
             Test.@test i_ray_hit_tile == convert(I, 5)
             Test.@test j_ray_hit_tile == convert(I, 4)
             Test.@test hit_dimension == 1
@@ -423,9 +423,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = 2" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 2)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 4)
-            Test.@test j_ray_stop_cell == convert(I, 5)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 4)
+            Test.@test j_ray_stop == convert(I, 5)
             Test.@test i_ray_hit_tile == convert(I, 4)
             Test.@test j_ray_hit_tile == convert(I, 5)
             Test.@test hit_dimension == 2
@@ -434,9 +434,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 0, delta_j = 1" begin
             i_ray_direction = convert(I, 0)
             j_ray_direction = convert(I, 1)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 3)
-            Test.@test j_ray_stop_cell == convert(I, 5)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 3)
+            Test.@test j_ray_stop == convert(I, 5)
             Test.@test i_ray_hit_tile == convert(I, 3)
             Test.@test j_ray_hit_tile == convert(I, 5)
             Test.@test hit_dimension == 2
@@ -445,9 +445,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = 2" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, 2)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 2)
-            Test.@test j_ray_stop_cell == convert(I, 4)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 2)
+            Test.@test j_ray_stop == convert(I, 4)
             Test.@test i_ray_hit_tile == convert(I, 1)
             Test.@test j_ray_hit_tile == convert(I, 4)
             Test.@test hit_dimension == 1
@@ -456,9 +456,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = 1" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, 1)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 2)
-            Test.@test j_ray_stop_cell == convert(I, 3)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 2)
+            Test.@test j_ray_stop == convert(I, 3)
             Test.@test i_ray_hit_tile == convert(I, 1)
             Test.@test j_ray_hit_tile == convert(I, 3)
             Test.@test hit_dimension == 1
@@ -467,9 +467,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -2, delta_j = 1" begin
             i_ray_direction = convert(I, -2)
             j_ray_direction = convert(I, 1)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 2)
-            Test.@test j_ray_stop_cell == convert(I, 3)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 2)
+            Test.@test j_ray_stop == convert(I, 3)
             Test.@test i_ray_hit_tile == convert(I, 1)
             Test.@test j_ray_hit_tile == convert(I, 3)
             Test.@test hit_dimension == 1
@@ -478,9 +478,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = 0" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, 0)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 2)
-            Test.@test j_ray_stop_cell == convert(I, 3)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 2)
+            Test.@test j_ray_stop == convert(I, 3)
             Test.@test i_ray_hit_tile == convert(I, 1)
             Test.@test j_ray_hit_tile == convert(I, 3)
             Test.@test hit_dimension == 1
@@ -489,9 +489,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -2, delta_j = -1" begin
             i_ray_direction = convert(I, -2)
             j_ray_direction = convert(I, -1)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 2)
-            Test.@test j_ray_stop_cell == convert(I, 2)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 2)
+            Test.@test j_ray_stop == convert(I, 2)
             Test.@test i_ray_hit_tile == convert(I, 1)
             Test.@test j_ray_hit_tile == convert(I, 2)
             Test.@test hit_dimension == 1
@@ -500,9 +500,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = -1" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, -1)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 2)
-            Test.@test j_ray_stop_cell == convert(I, 2)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 2)
+            Test.@test j_ray_stop == convert(I, 2)
             Test.@test i_ray_hit_tile == convert(I, 1)
             Test.@test j_ray_hit_tile == convert(I, 2)
             Test.@test hit_dimension == 1
@@ -511,9 +511,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = -1, delta_j = -2" begin
             i_ray_direction = convert(I, -1)
             j_ray_direction = convert(I, -2)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 2)
-            Test.@test j_ray_stop_cell == convert(I, 2)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 2)
+            Test.@test j_ray_stop == convert(I, 2)
             Test.@test i_ray_hit_tile == convert(I, 2)
             Test.@test j_ray_hit_tile == convert(I, 1)
             Test.@test hit_dimension == 2
@@ -522,9 +522,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 0, delta_j = -1" begin
             i_ray_direction = convert(I, 0)
             j_ray_direction = convert(I, -1)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 3)
-            Test.@test j_ray_stop_cell == convert(I, 2)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 3)
+            Test.@test j_ray_stop == convert(I, 2)
             Test.@test i_ray_hit_tile == convert(I, 3)
             Test.@test j_ray_hit_tile == convert(I, 1)
             Test.@test hit_dimension == 2
@@ -533,9 +533,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = -2" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, -2)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 3)
-            Test.@test j_ray_stop_cell == convert(I, 2)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 3)
+            Test.@test j_ray_stop == convert(I, 2)
             Test.@test i_ray_hit_tile == convert(I, 3)
             Test.@test j_ray_hit_tile == convert(I, 1)
             Test.@test hit_dimension == 2
@@ -544,9 +544,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 1, delta_j = -1" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, -1)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 4)
-            Test.@test j_ray_stop_cell == convert(I, 2)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 4)
+            Test.@test j_ray_stop == convert(I, 2)
             Test.@test i_ray_hit_tile == convert(I, 4)
             Test.@test j_ray_hit_tile == convert(I, 1)
             Test.@test hit_dimension == 2
@@ -555,9 +555,9 @@ Test.@testset "RayCaster.jl" begin
         Test.@testset "delta_i = 2, delta_j = -1" begin
             i_ray_direction = convert(I, 2)
             j_ray_direction = convert(I, -1)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 5)
-            Test.@test j_ray_stop_cell == convert(I, 2)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 5)
+            Test.@test j_ray_stop == convert(I, 2)
             Test.@test i_ray_hit_tile == convert(I, 5)
             Test.@test j_ray_hit_tile == convert(I, 2)
             Test.@test hit_dimension == 1
@@ -567,15 +567,15 @@ Test.@testset "RayCaster.jl" begin
     Test.@testset "starting inside an obstacle tile" begin
         cells_per_tile_1d = convert(I, 8)
 
-        i_ray_start_cell = convert(I, 3)
-        j_ray_start_cell = convert(I, 4)
+        i_ray_start = convert(I, 3)
+        j_ray_start = convert(I, 4)
 
         Test.@testset "delta_i = 1, delta_j = 0" begin
             i_ray_direction = convert(I, 1)
             j_ray_direction = convert(I, 0)
-            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
-            Test.@test i_ray_stop_cell == convert(I, 3)
-            Test.@test j_ray_stop_cell == convert(I, 4)
+            i_ray_stop, j_ray_stop, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start, j_ray_start, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop == convert(I, 3)
+            Test.@test j_ray_stop == convert(I, 4)
             Test.@test i_ray_hit_tile == convert(I, 1)
             Test.@test j_ray_hit_tile == convert(I, 1)
             Test.@test hit_dimension == 0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -197,4 +197,187 @@ Test.@testset "RayCaster.jl" begin
             Test.@test hit_dimension == 1
         end
     end
+
+    Test.@testset "cells_per_tile_1d = 9" begin
+        cells_per_tile_1d = convert(I, 9)
+
+        i_ray_start_cell = convert(I, (height_obstacle_tile_map * cells_per_tile_1d) ÷ 2 + 1)
+        j_ray_start_cell = convert(I, (width_obstacle_tile_map * cells_per_tile_1d) ÷ 2 + 1)
+
+        Test.@testset "delta_i = 1, delta_j = 0" begin
+            i_ray_direction = convert(I, 1)
+            j_ray_direction = convert(I, 0)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 36)
+            Test.@test j_ray_stop_cell == convert(I, 23)
+            Test.@test i_ray_hit_tile == convert(I, 5)
+            Test.@test j_ray_hit_tile == convert(I, 3)
+            Test.@test hit_dimension == 1
+        end
+
+        Test.@testset "delta_i = 2, delta_j = 1" begin
+            i_ray_direction = convert(I, 2)
+            j_ray_direction = convert(I, 1)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 36)
+            Test.@test j_ray_stop_cell == convert(I, 31)
+            Test.@test i_ray_hit_tile == convert(I, 5)
+            Test.@test j_ray_hit_tile == convert(I, 4)
+            Test.@test hit_dimension == 1
+        end
+
+        Test.@testset "delta_i = 1, delta_j = 1" begin
+            i_ray_direction = convert(I, 1)
+            j_ray_direction = convert(I, 1)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 36)
+            Test.@test j_ray_stop_cell == convert(I, 36)
+            Test.@test i_ray_hit_tile == convert(I, 5)
+            Test.@test j_ray_hit_tile == convert(I, 4)
+            Test.@test hit_dimension == 1
+        end
+
+        Test.@testset "delta_i = 1, delta_j = 2" begin
+            i_ray_direction = convert(I, 1)
+            j_ray_direction = convert(I, 2)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 31)
+            Test.@test j_ray_stop_cell == convert(I, 36)
+            Test.@test i_ray_hit_tile == convert(I, 4)
+            Test.@test j_ray_hit_tile == convert(I, 5)
+            Test.@test hit_dimension == 2
+        end
+
+        Test.@testset "delta_i = 0, delta_j = 1" begin
+            i_ray_direction = convert(I, 0)
+            j_ray_direction = convert(I, 1)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 23)
+            Test.@test j_ray_stop_cell == convert(I, 36)
+            Test.@test i_ray_hit_tile == convert(I, 3)
+            Test.@test j_ray_hit_tile == convert(I, 5)
+            Test.@test hit_dimension == 2
+        end
+
+        Test.@testset "delta_i = -1, delta_j = 2" begin
+            i_ray_direction = convert(I, -1)
+            j_ray_direction = convert(I, 2)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 15)
+            Test.@test j_ray_stop_cell == convert(I, 36)
+            Test.@test i_ray_hit_tile == convert(I, 2)
+            Test.@test j_ray_hit_tile == convert(I, 5)
+            Test.@test hit_dimension == 2
+        end
+
+        Test.@testset "delta_i = -1, delta_j = 1" begin
+            i_ray_direction = convert(I, -1)
+            j_ray_direction = convert(I, 1)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 10)
+            Test.@test j_ray_stop_cell == convert(I, 36)
+            Test.@test i_ray_hit_tile == convert(I, 1)
+            Test.@test j_ray_hit_tile == convert(I, 4)
+            Test.@test hit_dimension == 1
+        end
+
+        Test.@testset "delta_i = -2, delta_j = 1" begin
+            i_ray_direction = convert(I, -2)
+            j_ray_direction = convert(I, 1)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 10)
+            Test.@test j_ray_stop_cell == convert(I, 31)
+            Test.@test i_ray_hit_tile == convert(I, 1)
+            Test.@test j_ray_hit_tile == convert(I, 4)
+            Test.@test hit_dimension == 1
+        end
+
+        Test.@testset "delta_i = -1, delta_j = 0" begin
+            i_ray_direction = convert(I, -1)
+            j_ray_direction = convert(I, 0)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 10)
+            Test.@test j_ray_stop_cell == convert(I, 23)
+            Test.@test i_ray_hit_tile == convert(I, 1)
+            Test.@test j_ray_hit_tile == convert(I, 3)
+            Test.@test hit_dimension == 1
+        end
+
+        Test.@testset "delta_i = -2, delta_j = -1" begin
+            i_ray_direction = convert(I, -2)
+            j_ray_direction = convert(I, -1)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 10)
+            Test.@test j_ray_stop_cell == convert(I, 15)
+            Test.@test i_ray_hit_tile == convert(I, 1)
+            Test.@test j_ray_hit_tile == convert(I, 2)
+            Test.@test hit_dimension == 1
+        end
+
+        Test.@testset "delta_i = -1, delta_j = -1" begin
+            i_ray_direction = convert(I, -1)
+            j_ray_direction = convert(I, -1)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 10)
+            Test.@test j_ray_stop_cell == convert(I, 10)
+            Test.@test i_ray_hit_tile == convert(I, 1)
+            Test.@test j_ray_hit_tile == convert(I, 2)
+            Test.@test hit_dimension == 1
+        end
+
+        Test.@testset "delta_i = -1, delta_j = -2" begin
+            i_ray_direction = convert(I, -1)
+            j_ray_direction = convert(I, -2)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 15)
+            Test.@test j_ray_stop_cell == convert(I, 10)
+            Test.@test i_ray_hit_tile == convert(I, 2)
+            Test.@test j_ray_hit_tile == convert(I, 1)
+            Test.@test hit_dimension == 2
+        end
+
+        Test.@testset "delta_i = 0, delta_j = -1" begin
+            i_ray_direction = convert(I, 0)
+            j_ray_direction = convert(I, -1)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 23)
+            Test.@test j_ray_stop_cell == convert(I, 10)
+            Test.@test i_ray_hit_tile == convert(I, 3)
+            Test.@test j_ray_hit_tile == convert(I, 1)
+            Test.@test hit_dimension == 2
+        end
+
+        Test.@testset "delta_i = 1, delta_j = -2" begin
+            i_ray_direction = convert(I, 1)
+            j_ray_direction = convert(I, -2)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 31)
+            Test.@test j_ray_stop_cell == convert(I, 10)
+            Test.@test i_ray_hit_tile == convert(I, 4)
+            Test.@test j_ray_hit_tile == convert(I, 1)
+            Test.@test hit_dimension == 2
+        end
+
+        Test.@testset "delta_i = 1, delta_j = -1" begin
+            i_ray_direction = convert(I, 1)
+            j_ray_direction = convert(I, -1)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 36)
+            Test.@test j_ray_stop_cell == convert(I, 10)
+            Test.@test i_ray_hit_tile == convert(I, 5)
+            Test.@test j_ray_hit_tile == convert(I, 2)
+            Test.@test hit_dimension == 1
+        end
+
+        Test.@testset "delta_i = 2, delta_j = -1" begin
+            i_ray_direction = convert(I, 2)
+            j_ray_direction = convert(I, -1)
+            i_ray_stop_cell, j_ray_stop_cell, i_ray_hit_tile, j_ray_hit_tile, hit_dimension = RC.cast_ray(obstacle_tile_map, cells_per_tile_1d, i_ray_start_cell, j_ray_start_cell, i_ray_direction, j_ray_direction, max_steps)
+            Test.@test i_ray_stop_cell == convert(I, 36)
+            Test.@test j_ray_stop_cell == convert(I, 15)
+            Test.@test i_ray_hit_tile == convert(I, 5)
+            Test.@test j_ray_hit_tile == convert(I, 2)
+            Test.@test hit_dimension == 1
+        end
+    end
 end


### PR DESCRIPTION
1. Use lattice point coordinates and lines instead of `cells` for ray coordinates.
1. Add `i_ray_stop`, `j_ray_stop` and remove `signed_perpendicular_distance_to_obstacle` from returned output.
1. Rename a bunch of variables.
1. Add several tests.
1. Remove `cell_coordinate_to_tile_coordinate` and `cell_to_tile`
1. Add assertions for `i_ray_direction` and `j_ray_direction` to not be simultaneously zero.

